### PR TITLE
Trippy now available on NetBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Feature status and high level roadmap:
 cargo install trippy
 ```
 
+### NetBSD
+```shell
+pkgin install trippy
+```
+
 ### Docker (Linux only)
 
 ```shell
@@ -70,7 +75,7 @@ Trippy has been (lightly...) tested on the following platforms:
 |----------------|-----------------|--------|
 | Linux (Ubuntu) | 20.04           | ✅      |
 | macOS          | 11.4 (Big Sur)  | ✅      |
-| BSD            | n/a             | TBC    |
+| NetBSD         | current         | ✅      |
 | Windows        | n/a             | TBC    |
 
 ## Privileges


### PR DESCRIPTION
I've just packaged and merged `trippy` into the main branch of pkgsrc.
This means the application is now available for NetBSD users. It builds and runs fine on NetBSD.
https://mail-index.netbsd.org/pkgsrc-changes/2022/05/01/msg253439.html

Regards