### PR TITLE
doc: Use project README.md as documentation for the library crate on `docs.rs` (#128)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-//! Trippy
-//!
+#![doc = include_str!("../README.md")]
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, rust_2018_idioms)]
 #![allow(
     clippy::module_name_repetitions,


### PR DESCRIPTION
Closes #128 