### PR TITLE
fix(report): setting `--report-cycles` to `1` returns no traces (#189)

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -12,7 +12,7 @@ pub struct Trace {
     max_samples: usize,
     lowest_ttl: u8,
     highest_ttl: u8,
-    round: usize,
+    round: Option<usize>,
     hops: Vec<Hop>,
     error: Option<String>,
 }
@@ -23,14 +23,14 @@ impl Trace {
             max_samples,
             lowest_ttl: 0,
             highest_ttl: 0,
-            round: 0,
+            round: None,
             hops: (0..MAX_HOPS).map(|_| Hop::default()).collect(),
             error: None,
         }
     }
 
     /// The current round of tracing.
-    pub fn round(&self) -> usize {
+    pub fn round(&self) -> Option<usize> {
         self.round
     }
 
@@ -130,7 +130,10 @@ impl Trace {
     /// Update `round` for valid probes.
     fn update_round(&mut self, probe: &Probe) {
         if matches!(probe.status, ProbeStatus::Awaited | ProbeStatus::Complete) {
-            self.round = self.round.max(probe.round.0);
+            self.round = match self.round {
+                None => Some(probe.round.0),
+                Some(r) => Some(r.max(probe.round.0)),
+            }
         }
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -253,9 +253,9 @@ pub fn run_report_stream(info: &TraceInfo) -> anyhow::Result<()> {
 }
 
 /// Block until trace data for round `round` is available.
-fn wait_for_round(trace_data: &Arc<RwLock<Trace>>, round: usize) -> anyhow::Result<Trace> {
+fn wait_for_round(trace_data: &Arc<RwLock<Trace>>, report_cycles: usize) -> anyhow::Result<Trace> {
     let mut trace = trace_data.read().clone();
-    while trace.round() < round - 1 {
+    while trace.round().is_none() || trace.round() < Some(report_cycles - 1) {
         trace = trace_data.read().clone();
         if let Some(err) = trace.error() {
             return Err(anyhow!("error: {}", err));


### PR DESCRIPTION
Closes #189 