### PR TITLE
refactor: simplify `Buffer::get_bytes_xxx` and `Buffer::set_bytes_xxx`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - build: linux-pinned
             os: ubuntu-20.04
-            rust: 1.60.0
+            rust: 1.63.0
           - build: linux-stable
             os: ubuntu-20.04
             rust: stable
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [ stable, beta, nightly, 1.60.0 ]
+        rust: [ stable, beta, nightly, 1.63.0 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [ stable, beta, nightly, 1.60.0 ]
+        rust: [ stable, beta, nightly, 1.63.0 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.60.0 as build-env
+FROM rust:1.63.0 as build-env
 WORKDIR /app
 COPY Cargo.toml /app
 COPY Cargo.lock /app

--- a/src/tracing/packet/buffer.rs
+++ b/src/tracing/packet/buffer.rs
@@ -14,55 +14,16 @@ impl<'a> Buffer<'a> {
         }
     }
 
-    /// Get 16 bytes from the packet at a given byte offset.
-    pub fn get_bytes_16(&self, offset: usize) -> [u8; 16] {
-        [
-            self.read(offset),
-            self.read(offset + 1),
-            self.read(offset + 2),
-            self.read(offset + 3),
-            self.read(offset + 4),
-            self.read(offset + 5),
-            self.read(offset + 6),
-            self.read(offset + 7),
-            self.read(offset + 8),
-            self.read(offset + 9),
-            self.read(offset + 10),
-            self.read(offset + 11),
-            self.read(offset + 12),
-            self.read(offset + 13),
-            self.read(offset + 14),
-            self.read(offset + 15),
-        ]
+    /// Get N bytes from the packet at a given byte offset.
+    pub fn get_bytes<const N: usize>(&self, offset: usize) -> [u8; N] {
+        core::array::from_fn(|i| self.read(offset + i))
     }
 
-    /// Get two bytes from the packet at a given byte offset.
-    pub fn get_bytes_two(&self, offset: usize) -> [u8; 2] {
-        [self.read(offset), self.read(offset + 1)]
-    }
-
-    /// Get four bytes from the packet at a given byte offset.
-    pub fn get_bytes_four(&self, offset: usize) -> [u8; 4] {
-        [
-            self.read(offset),
-            self.read(offset + 1),
-            self.read(offset + 2),
-            self.read(offset + 3),
-        ]
-    }
-
-    /// Set two bytes in the packet at a given offset.
-    pub fn set_bytes_two(&mut self, offset: usize, bytes: [u8; 2]) {
-        *self.write(offset) = bytes[0];
-        *self.write(offset + 1) = bytes[1];
-    }
-
-    /// Set four bytes in the packet at a given offset.
-    pub fn set_bytes_four(&mut self, offset: usize, bytes: [u8; 4]) {
-        *self.write(offset) = bytes[0];
-        *self.write(offset + 1) = bytes[1];
-        *self.write(offset + 2) = bytes[2];
-        *self.write(offset + 3) = bytes[3];
+    /// Set N bytes in the packet at a given offset.
+    pub fn set_bytes<const N: usize>(&mut self, offset: usize, bytes: [u8; N]) {
+        for (i, b) in bytes.into_iter().enumerate() {
+            *self.write(offset + i) = b;
+        }
     }
 
     /// Get the value at a given offset.

--- a/src/tracing/packet/icmpv4.rs
+++ b/src/tracing/packet/icmpv4.rs
@@ -97,7 +97,7 @@ impl<'a> IcmpPacket<'a> {
 
     #[must_use]
     pub fn get_checksum(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(CHECKSUM_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
     }
 
     pub fn set_icmp_type(&mut self, val: IcmpType) {
@@ -109,7 +109,7 @@ impl<'a> IcmpPacket<'a> {
     }
 
     pub fn set_checksum(&mut self, val: u16) {
-        self.buf.set_bytes_two(CHECKSUM_OFFSET, val.to_be_bytes());
+        self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
     }
 
     #[must_use]
@@ -243,17 +243,17 @@ pub mod echo_request {
 
         #[must_use]
         pub fn get_checksum(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(CHECKSUM_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
         }
 
         #[must_use]
         pub fn get_identifier(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(IDENTIFIER_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(IDENTIFIER_OFFSET))
         }
 
         #[must_use]
         pub fn get_sequence(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(SEQUENCE_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(SEQUENCE_OFFSET))
         }
 
         pub fn set_icmp_type(&mut self, val: IcmpType) {
@@ -265,15 +265,15 @@ pub mod echo_request {
         }
 
         pub fn set_checksum(&mut self, val: u16) {
-            self.buf.set_bytes_two(CHECKSUM_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_identifier(&mut self, val: u16) {
-            self.buf.set_bytes_two(IDENTIFIER_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(IDENTIFIER_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_sequence(&mut self, val: u16) {
-            self.buf.set_bytes_two(SEQUENCE_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(SEQUENCE_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_payload(&mut self, vals: &[u8]) {
@@ -464,17 +464,17 @@ pub mod echo_reply {
 
         #[must_use]
         pub fn get_checksum(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(CHECKSUM_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
         }
 
         #[must_use]
         pub fn get_identifier(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(IDENTIFIER_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(IDENTIFIER_OFFSET))
         }
 
         #[must_use]
         pub fn get_sequence(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(SEQUENCE_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(SEQUENCE_OFFSET))
         }
 
         pub fn set_icmp_type(&mut self, val: IcmpType) {
@@ -486,15 +486,15 @@ pub mod echo_reply {
         }
 
         pub fn set_checksum(&mut self, val: u16) {
-            self.buf.set_bytes_two(CHECKSUM_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_identifier(&mut self, val: u16) {
-            self.buf.set_bytes_two(IDENTIFIER_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(IDENTIFIER_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_sequence(&mut self, val: u16) {
-            self.buf.set_bytes_two(SEQUENCE_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(SEQUENCE_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_payload(&mut self, vals: &[u8]) {
@@ -683,7 +683,7 @@ pub mod time_exceeded {
 
         #[must_use]
         pub fn get_checksum(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(CHECKSUM_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
         }
 
         pub fn set_icmp_type(&mut self, val: IcmpType) {
@@ -695,7 +695,7 @@ pub mod time_exceeded {
         }
 
         pub fn set_checksum(&mut self, val: u16) {
-            self.buf.set_bytes_two(CHECKSUM_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_payload(&mut self, vals: &[u8]) {
@@ -852,17 +852,17 @@ pub mod destination_unreachable {
 
         #[must_use]
         pub fn get_checksum(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(CHECKSUM_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
         }
 
         #[must_use]
         pub fn get_unused(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(UNUSED_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(UNUSED_OFFSET))
         }
 
         #[must_use]
         pub fn get_next_hop_mtu(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(NEXT_HOP_MTU_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(NEXT_HOP_MTU_OFFSET))
         }
 
         pub fn set_icmp_type(&mut self, val: IcmpType) {
@@ -874,16 +874,15 @@ pub mod destination_unreachable {
         }
 
         pub fn set_checksum(&mut self, val: u16) {
-            self.buf.set_bytes_two(CHECKSUM_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_unused(&mut self, val: u16) {
-            self.buf.set_bytes_two(UNUSED_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(UNUSED_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_next_hop_mtu(&mut self, val: u16) {
-            self.buf
-                .set_bytes_two(NEXT_HOP_MTU_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(NEXT_HOP_MTU_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_payload(&mut self, vals: &[u8]) {

--- a/src/tracing/packet/icmpv6.rs
+++ b/src/tracing/packet/icmpv6.rs
@@ -97,7 +97,7 @@ impl<'a> IcmpPacket<'a> {
 
     #[must_use]
     pub fn get_checksum(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(CHECKSUM_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
     }
 
     pub fn set_icmp_type(&mut self, val: IcmpType) {
@@ -109,7 +109,7 @@ impl<'a> IcmpPacket<'a> {
     }
 
     pub fn set_checksum(&mut self, val: u16) {
-        self.buf.set_bytes_two(CHECKSUM_OFFSET, val.to_be_bytes());
+        self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
     }
 
     #[must_use]
@@ -243,17 +243,17 @@ pub mod echo_request {
 
         #[must_use]
         pub fn get_checksum(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(CHECKSUM_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
         }
 
         #[must_use]
         pub fn get_identifier(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(IDENTIFIER_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(IDENTIFIER_OFFSET))
         }
 
         #[must_use]
         pub fn get_sequence(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(SEQUENCE_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(SEQUENCE_OFFSET))
         }
 
         pub fn set_icmp_type(&mut self, val: IcmpType) {
@@ -265,15 +265,15 @@ pub mod echo_request {
         }
 
         pub fn set_checksum(&mut self, val: u16) {
-            self.buf.set_bytes_two(CHECKSUM_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_identifier(&mut self, val: u16) {
-            self.buf.set_bytes_two(IDENTIFIER_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(IDENTIFIER_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_sequence(&mut self, val: u16) {
-            self.buf.set_bytes_two(SEQUENCE_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(SEQUENCE_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_payload(&mut self, vals: &[u8]) {
@@ -464,17 +464,17 @@ pub mod echo_reply {
 
         #[must_use]
         pub fn get_checksum(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(CHECKSUM_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
         }
 
         #[must_use]
         pub fn get_identifier(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(IDENTIFIER_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(IDENTIFIER_OFFSET))
         }
 
         #[must_use]
         pub fn get_sequence(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(SEQUENCE_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(SEQUENCE_OFFSET))
         }
 
         pub fn set_icmp_type(&mut self, val: IcmpType) {
@@ -486,15 +486,15 @@ pub mod echo_reply {
         }
 
         pub fn set_checksum(&mut self, val: u16) {
-            self.buf.set_bytes_two(CHECKSUM_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_identifier(&mut self, val: u16) {
-            self.buf.set_bytes_two(IDENTIFIER_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(IDENTIFIER_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_sequence(&mut self, val: u16) {
-            self.buf.set_bytes_two(SEQUENCE_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(SEQUENCE_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_payload(&mut self, vals: &[u8]) {
@@ -683,7 +683,7 @@ pub mod time_exceeded {
 
         #[must_use]
         pub fn get_checksum(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(CHECKSUM_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
         }
 
         pub fn set_icmp_type(&mut self, val: IcmpType) {
@@ -695,7 +695,7 @@ pub mod time_exceeded {
         }
 
         pub fn set_checksum(&mut self, val: u16) {
-            self.buf.set_bytes_two(CHECKSUM_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_payload(&mut self, vals: &[u8]) {
@@ -852,17 +852,17 @@ pub mod destination_unreachable {
 
         #[must_use]
         pub fn get_checksum(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(CHECKSUM_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
         }
 
         #[must_use]
         pub fn get_unused(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(UNUSED_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(UNUSED_OFFSET))
         }
 
         #[must_use]
         pub fn get_next_hop_mtu(&self) -> u16 {
-            u16::from_be_bytes(self.buf.get_bytes_two(NEXT_HOP_MTU_OFFSET))
+            u16::from_be_bytes(self.buf.get_bytes(NEXT_HOP_MTU_OFFSET))
         }
 
         pub fn set_icmp_type(&mut self, val: IcmpType) {
@@ -874,16 +874,15 @@ pub mod destination_unreachable {
         }
 
         pub fn set_checksum(&mut self, val: u16) {
-            self.buf.set_bytes_two(CHECKSUM_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_unused(&mut self, val: u16) {
-            self.buf.set_bytes_two(UNUSED_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(UNUSED_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_next_hop_mtu(&mut self, val: u16) {
-            self.buf
-                .set_bytes_two(NEXT_HOP_MTU_OFFSET, val.to_be_bytes());
+            self.buf.set_bytes(NEXT_HOP_MTU_OFFSET, val.to_be_bytes());
         }
 
         pub fn set_payload(&mut self, vals: &[u8]) {

--- a/src/tracing/packet/ipv4.rs
+++ b/src/tracing/packet/ipv4.rs
@@ -73,17 +73,17 @@ impl<'a> Ipv4Packet<'a> {
 
     #[must_use]
     pub fn get_total_length(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(TOTAL_LENGTH_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(TOTAL_LENGTH_OFFSET))
     }
 
     #[must_use]
     pub fn get_identification(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(IDENTIFICATION_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(IDENTIFICATION_OFFSET))
     }
 
     #[must_use]
     pub fn get_flags_and_fragment_offset(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(FLAGS_AND_FRAGMENT_OFFSET_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(FLAGS_AND_FRAGMENT_OFFSET_OFFSET))
     }
 
     #[must_use]
@@ -98,7 +98,7 @@ impl<'a> Ipv4Packet<'a> {
 
     #[must_use]
     pub fn get_checksum(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(CHECKSUM_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
     }
 
     #[must_use]
@@ -149,18 +149,16 @@ impl<'a> Ipv4Packet<'a> {
     }
 
     pub fn set_total_length(&mut self, val: u16) {
-        self.buf
-            .set_bytes_two(TOTAL_LENGTH_OFFSET, val.to_be_bytes());
+        self.buf.set_bytes(TOTAL_LENGTH_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_identification(&mut self, val: u16) {
-        self.buf
-            .set_bytes_two(IDENTIFICATION_OFFSET, val.to_be_bytes());
+        self.buf.set_bytes(IDENTIFICATION_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_flags_and_fragment_offset(&mut self, val: u16) {
         self.buf
-            .set_bytes_two(FLAGS_AND_FRAGMENT_OFFSET_OFFSET, val.to_be_bytes());
+            .set_bytes(FLAGS_AND_FRAGMENT_OFFSET_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_ttl(&mut self, val: u8) {
@@ -172,7 +170,7 @@ impl<'a> Ipv4Packet<'a> {
     }
 
     pub fn set_checksum(&mut self, val: u16) {
-        self.buf.set_bytes_two(CHECKSUM_OFFSET, val.to_be_bytes());
+        self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_source(&mut self, val: Ipv4Addr) {

--- a/src/tracing/packet/ipv6.rs
+++ b/src/tracing/packet/ipv6.rs
@@ -69,7 +69,7 @@ impl<'a> Ipv6Packet<'a> {
 
     #[must_use]
     pub fn get_payload_length(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(PAYLOAD_LENGTH_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(PAYLOAD_LENGTH_OFFSET))
     }
 
     #[must_use]
@@ -84,12 +84,12 @@ impl<'a> Ipv6Packet<'a> {
 
     #[must_use]
     pub fn get_source_address(&self) -> Ipv6Addr {
-        Ipv6Addr::from(self.buf.get_bytes_16(SOURCE_ADDRESS_OFFSET))
+        Ipv6Addr::from(self.buf.get_bytes(SOURCE_ADDRESS_OFFSET))
     }
 
     #[must_use]
     pub fn get_destination_address(&self) -> Ipv6Addr {
-        Ipv6Addr::from(self.buf.get_bytes_16(DESTINATION_ADDRESS_OFFSET))
+        Ipv6Addr::from(self.buf.get_bytes(DESTINATION_ADDRESS_OFFSET))
     }
 
     pub fn set_version(&mut self, val: u8) {
@@ -112,8 +112,7 @@ impl<'a> Ipv6Packet<'a> {
     }
 
     pub fn set_payload_length(&mut self, val: u16) {
-        self.buf
-            .set_bytes_two(PAYLOAD_LENGTH_OFFSET, val.to_be_bytes());
+        self.buf.set_bytes(PAYLOAD_LENGTH_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_next_header(&mut self, val: IpProtocol) {

--- a/src/tracing/packet/tcp.rs
+++ b/src/tracing/packet/tcp.rs
@@ -50,22 +50,22 @@ impl<'a> TcpPacket<'a> {
 
     #[must_use]
     pub fn get_source(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(SOURCE_PORT_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(SOURCE_PORT_OFFSET))
     }
 
     #[must_use]
     pub fn get_destination(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(DESTINATION_PORT_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(DESTINATION_PORT_OFFSET))
     }
 
     #[must_use]
     pub fn get_sequence(&self) -> u32 {
-        u32::from_be_bytes(self.buf.get_bytes_four(SEQUENCE_OFFSET))
+        u32::from_be_bytes(self.buf.get_bytes(SEQUENCE_OFFSET))
     }
 
     #[must_use]
     pub fn get_acknowledgement(&self) -> u32 {
-        u32::from_be_bytes(self.buf.get_bytes_four(ACKNOWLEDGEMENT_OFFSET))
+        u32::from_be_bytes(self.buf.get_bytes(ACKNOWLEDGEMENT_OFFSET))
     }
 
     #[must_use]
@@ -88,17 +88,17 @@ impl<'a> TcpPacket<'a> {
 
     #[must_use]
     pub fn get_window_size(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(WINDOW_SIZE_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(WINDOW_SIZE_OFFSET))
     }
 
     #[must_use]
     pub fn get_checksum(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(CHECKSUM_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
     }
 
     #[must_use]
     pub fn get_urgent_pointer(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(URGENT_POINTER_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(URGENT_POINTER_OFFSET))
     }
 
     #[must_use]
@@ -112,22 +112,21 @@ impl<'a> TcpPacket<'a> {
     }
 
     pub fn set_source(&mut self, val: u16) {
-        self.buf
-            .set_bytes_two(SOURCE_PORT_OFFSET, val.to_be_bytes());
+        self.buf.set_bytes(SOURCE_PORT_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_destination(&mut self, val: u16) {
         self.buf
-            .set_bytes_two(DESTINATION_PORT_OFFSET, val.to_be_bytes());
+            .set_bytes(DESTINATION_PORT_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_sequence(&mut self, val: u32) {
-        self.buf.set_bytes_four(SEQUENCE_OFFSET, val.to_be_bytes());
+        self.buf.set_bytes(SEQUENCE_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_acknowledgement(&mut self, val: u32) {
         self.buf
-            .set_bytes_four(ACKNOWLEDGEMENT_OFFSET, val.to_be_bytes());
+            .set_bytes(ACKNOWLEDGEMENT_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_data_offset(&mut self, val: u8) {
@@ -147,17 +146,15 @@ impl<'a> TcpPacket<'a> {
     }
 
     pub fn set_window_size(&mut self, val: u16) {
-        self.buf
-            .set_bytes_two(WINDOW_SIZE_OFFSET, val.to_be_bytes());
+        self.buf.set_bytes(WINDOW_SIZE_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_checksum(&mut self, val: u16) {
-        self.buf.set_bytes_two(CHECKSUM_OFFSET, val.to_be_bytes());
+        self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_urgent_pointer(&mut self, val: u16) {
-        self.buf
-            .set_bytes_two(URGENT_POINTER_OFFSET, val.to_be_bytes());
+        self.buf.set_bytes(URGENT_POINTER_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_payload(&mut self, vals: &[u8]) {

--- a/src/tracing/packet/udp.rs
+++ b/src/tracing/packet/udp.rs
@@ -44,40 +44,39 @@ impl<'a> UdpPacket<'a> {
 
     #[must_use]
     pub fn get_source(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(SOURCE_PORT_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(SOURCE_PORT_OFFSET))
     }
 
     #[must_use]
     pub fn get_destination(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(DESTINATION_PORT_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(DESTINATION_PORT_OFFSET))
     }
 
     #[must_use]
     pub fn get_length(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(LENGTH_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(LENGTH_OFFSET))
     }
 
     #[must_use]
     pub fn get_checksum(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes_two(CHECKSUM_OFFSET))
+        u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
     }
 
     pub fn set_source(&mut self, val: u16) {
-        self.buf
-            .set_bytes_two(SOURCE_PORT_OFFSET, val.to_be_bytes());
+        self.buf.set_bytes(SOURCE_PORT_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_destination(&mut self, val: u16) {
         self.buf
-            .set_bytes_two(DESTINATION_PORT_OFFSET, val.to_be_bytes());
+            .set_bytes(DESTINATION_PORT_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_length(&mut self, val: u16) {
-        self.buf.set_bytes_two(LENGTH_OFFSET, val.to_be_bytes());
+        self.buf.set_bytes(LENGTH_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_checksum(&mut self, val: u16) {
-        self.buf.set_bytes_two(CHECKSUM_OFFSET, val.to_be_bytes());
+        self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
     }
 
     pub fn set_payload(&mut self, vals: &[u8]) {


### PR DESCRIPTION
…` methods using const generics