### PR TITLE
fix: remove redundant bind call for ICMP and UDP tracing over IPv6

### DIFF
--- a/src/tracing/net/ipv6.rs
+++ b/src/tracing/net/ipv6.rs
@@ -56,8 +56,6 @@ pub fn dispatch_icmp_probe(
         icmp_payload_size(packet_size),
         payload_pattern,
     )?;
-    let local_addr = SocketAddr::new(IpAddr::V6(src_addr), 0);
-    icmp_send_socket.bind(local_addr)?;
     icmp_send_socket.set_unicast_hops_v6(u32::from(probe.ttl.0))?;
     let remote_addr = SocketAddr::new(IpAddr::V6(dest_addr), 0);
     icmp_send_socket.send_to(echo_request.packet(), remote_addr)?;
@@ -93,10 +91,7 @@ pub fn dispatch_udp_probe(
         udp_payload_size(packet_size),
         payload_pattern,
     )?;
-    let local_addr = SocketAddr::new(IpAddr::V6(src_addr), src_port);
-    udp_send_socket.bind(local_addr)?;
     udp_send_socket.set_unicast_hops_v6(u32::from(probe.ttl.0))?;
-
     // Note that we set the port to be 0 in the remote `SocketAddr` as the target port is encoded in the `UDP`
     // packet.  If we (redundantly) set the target port here then the send will fail with `EINVAL`.
     let remote_addr = SocketAddr::new(IpAddr::V6(dest_addr), 0);


### PR DESCRIPTION
Removed to align with the Windows implementation.  Tested on MacOS and Linux for ICMP and UDP.