### PR TITLE
fix: `tcp` tracing may ignore some incoming `icmp` responses (#407)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Variable Equal Cost Multi-path Routing (ECMP) causing truncated
   trace ([#269](https://github.com/fujiapple852/trippy/issues/269))
+- Tracing using the `tcp` may ignore some incoming `icmp`
+  responses ([#407](https://github.com/fujiapple852/trippy/issues/407))
 
 ## [0.6.0] - 2022-08-19
 

--- a/src/tracing/net/channel.rs
+++ b/src/tracing/net/channel.rs
@@ -89,7 +89,10 @@ impl Network for TracerChannel {
     fn recv_probe(&mut self) -> TraceResult<Option<ProbeResponse>> {
         match self.protocol {
             TracerProtocol::Icmp | TracerProtocol::Udp => self.recv_icmp_probe(),
-            TracerProtocol::Tcp => Ok(self.recv_tcp_sockets()?.or(self.recv_icmp_probe()?)),
+            TracerProtocol::Tcp => match self.recv_tcp_sockets()? {
+                None => self.recv_icmp_probe(),
+                resp => Ok(resp),
+            },
         }
     }
 }


### PR DESCRIPTION
Closes #407 