### PR TITLE
feat!: use XDG conventions on macOS too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,26 +412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
-dependencies = [
- "libc",
- "redox_users",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "dns-lookup"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +460,17 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -568,6 +559,15 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "hostname"
@@ -1025,17 +1025,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
-]
-
-[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,8 +1433,8 @@ dependencies = [
  "crossbeam",
  "crossterm 0.26.1",
  "derive_more",
- "dirs",
  "dns-lookup",
+ "etcetera",
  "humantime",
  "indexmap",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ serde = { version = "1.0.160", features = [ "derive" ] }
 serde_json = "1.0.96"
 comfy-table = "6.1.4"
 strum = { version = "0.24.1", features = [ "derive" ] }
-dirs = "5.0.0"
+etcetera = "0.8.0"
 toml = "0.7.3"
 indexmap = "1.9.3"
 maxminddb = "0.23.0"

--- a/README.md
+++ b/README.md
@@ -594,23 +594,12 @@ Trippy can be configured with via command line arguments or an optional configur
 item is specified in both the configuration file and via a command line argument then the latter will take precedence.
 
 The configuration file location may be provided to trippy via the `-c` (`--config-file`) argument. If not provided,
-Trippy will attempt to locate a `trippy.toml` or `.trippy.toml` configuration file in one of the following platform
-specific locations:
+Trippy will attempt to locate a `trippy.toml` or `.trippy.toml` configuration file in one of the following locations:
 
 - The current directory
 - The user home directory
-- The user config direction
-
-For example, on Linux Trippy will attempt to locate the following config files (in order):
-
-- `./trippy.toml`
-- `./.trippy.toml`
-- `$HOME/trippy.toml`
-- `$HOME/.trippy.toml`
-- `$HOME/.config/trippy.toml`
-- `$HOME/.config/.trippy.toml`
-
-See [here](https://github.com/dirs-dev/dirs-rs) for platform specific directory information.
+- the XDG config directory (Unix only): `$XDG_CONFIG_HOME` or `~/.config`
+- the Windows data directory (Windows only): `%APPDATA%`
 
 An annotated [template configuration file](trippy-config-sample.toml) is available.
 

--- a/trippy-config-sample.toml
+++ b/trippy-config-sample.toml
@@ -3,22 +3,11 @@
 # Copy this template config file to your platform specific config dir.
 #
 # Trippy will attempt to locate a `trippy.toml` or `.trippy.toml` config file
-# in one of the following platform specific locations:
+# in one of the following locations:
 #   the current directory
 #   the user home directory
-#   the user config directory
-#
-# For example, on Linux the Trippy will attempt to locate the following
-# files (in order):
-#   `./trippy.toml`
-#   `./.trippy.toml`
-#   `$HOME/trippy.toml`
-#   `$HOME/.trippy.toml`
-#   `$HOME/.config/trippy.toml`
-#   `$HOME/.config/.trippy.toml`
-#
-# See https://github.com/dirs-dev/dirs-rs for platform specific directory
-# information.
+#   the XDG config directory (Unix only): `$XDG_CONFIG_HOME` or `~/.config`
+#   the Windows data directory (Windows only): `%APPDATA%`
 #
 # You may override the config file name and location by passing the `-c`
 # (`--config-file`) command line argument.


### PR DESCRIPTION
`~/Library/Application Support` is an utterly inconvenient location for macOS users. Most CLI tools follow the `XDG conventions` on macOS as well. Replace the `dirs` crate with the `etcetera` crate to support it on macOS as well. Config locations for other platforms are unaffected.

Closes #539.
Closes #540.
Closes #541.