### PR TITLE
Ipv4 and Ipv6 packet truncation

### DIFF
--- a/src/tracing/net/ipv4.rs
+++ b/src/tracing/net/ipv4.rs
@@ -190,8 +190,8 @@ pub fn recv_icmp_probe(
 ) -> TraceResult<Option<ProbeResponse>> {
     let mut buf = [0_u8; MAX_PACKET_SIZE];
     match recv_socket.read(&mut buf) {
-        Ok(_bytes_read) => {
-            let ipv4 = Ipv4Packet::new_view(&buf).req()?;
+        Ok(bytes_read) => {
+            let ipv4 = Ipv4Packet::new_view(&buf[..bytes_read]).req()?;
             Ok(extract_probe_resp(protocol, &ipv4)?)
         }
         Err(err) => match err.kind() {

--- a/src/tracing/net/ipv6.rs
+++ b/src/tracing/net/ipv6.rs
@@ -142,8 +142,8 @@ pub fn recv_icmp_probe(
 ) -> TraceResult<Option<ProbeResponse>> {
     let mut buf = [0_u8; MAX_PACKET_SIZE];
     match recv_socket.recv_from(&mut buf) {
-        Ok((_bytes_read, addr)) => {
-            let icmp_v6 = IcmpPacket::new_view(&buf).req()?;
+        Ok((bytes_read, addr)) => {
+            let icmp_v6 = IcmpPacket::new_view(&buf[..bytes_read]).req()?;
             let src_addr = match addr.as_ref().req()? {
                 SocketAddr::V6(addr) => addr.ip(),
                 SocketAddr::V4(_) => panic!(),

--- a/src/tracing/packet/ipv4.rs
+++ b/src/tracing/packet/ipv4.rs
@@ -183,10 +183,6 @@ impl<'a> Ipv4Packet<'a> {
 
     pub fn set_payload(&mut self, vals: &[u8]) {
         let current_offset = Self::minimum_packet_size() + ipv4_options_length(self);
-        debug_assert!(
-            (vals.len() <= ipv4_payload_length(self)),
-            "vals.len() <= len"
-        );
         self.buf.as_slice_mut()[current_offset..current_offset + vals.len()].copy_from_slice(vals);
     }
 
@@ -197,24 +193,13 @@ impl<'a> Ipv4Packet<'a> {
 
     #[must_use]
     pub fn payload(&self) -> &[u8] {
-        let start = Self::minimum_packet_size() + ipv4_options_length(self);
-        let end = std::cmp::min(
-            Self::minimum_packet_size() + ipv4_options_length(self) + ipv4_payload_length(self),
-            self.buf.as_slice().len(),
-        );
-        if self.buf.as_slice().len() <= start {
-            return &[];
-        }
-        &self.buf.as_slice()[start..end]
+        let start = Ipv4Packet::minimum_packet_size() + ipv4_options_length(self);
+        &self.buf.as_slice()[start..]
     }
 }
 
 fn ipv4_options_length(ipv4: &Ipv4Packet<'_>) -> usize {
     (ipv4.get_header_length() as usize * 4).saturating_sub(Ipv4Packet::minimum_packet_size())
-}
-
-fn ipv4_payload_length(ipv4: &Ipv4Packet<'_>) -> usize {
-    (ipv4.get_total_length() as usize).saturating_sub(ipv4.get_header_length() as usize * 4)
 }
 
 impl Debug for Ipv4Packet<'_> {


### PR DESCRIPTION
Closes #686 

Todo:

- [x] Add Windows support for returning `bytes_read`
- [ ] Test on all platforms (different platforms may or may not adjust the Ipv4 total_length for raw sockets)
