### PR TITLE
refactor: Generic socket

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::instrument;
 use trippy::tracing::{
-    Probe, ProbeStatus, Tracer, TracerChannel, TracerChannelConfig, TracerConfig, TracerRound,
+    Probe, ProbeStatus, Socket, Tracer, TracerChannel, TracerChannelConfig, TracerConfig,
+    TracerRound,
 };
 
 /// The state of all hops in a trace.
@@ -274,7 +275,7 @@ pub fn run_backend(
     trace_data: Arc<RwLock<Trace>>,
 ) -> anyhow::Result<()> {
     let td = trace_data.clone();
-    let channel = TracerChannel::connect(channel_config)?;
+    let channel = TracerChannel::<Socket>::connect(channel_config)?;
     drop_caps()?;
     let tracer = Tracer::new(tracer_config, move |round| {
         trace_data.write().update_from_round(round);

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::instrument;
 use trippy::tracing::{
-    Probe, ProbeStatus, Socket, Tracer, TracerChannel, TracerChannelConfig, TracerConfig,
+    Probe, ProbeStatus, SocketImpl, Tracer, TracerChannel, TracerChannelConfig, TracerConfig,
     TracerRound,
 };
 
@@ -275,7 +275,7 @@ pub fn run_backend(
     trace_data: Arc<RwLock<Trace>>,
 ) -> anyhow::Result<()> {
     let td = trace_data.clone();
-    let channel = TracerChannel::<Socket>::connect(channel_config)?;
+    let channel = TracerChannel::<SocketImpl>::connect(channel_config)?;
     drop_caps()?;
     let tracer = Tracer::new(tracer_config, move |round| {
         trace_data.write().update_from_round(round);

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -16,5 +16,6 @@ pub use config::{
 };
 pub use net::channel::TracerChannel;
 pub use net::source::SourceAddr;
+pub use net::Socket;
 pub use probe::{IcmpPacketType, Probe, ProbeStatus};
 pub use tracer::{Tracer, TracerRound};

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -16,6 +16,6 @@ pub use config::{
 };
 pub use net::channel::TracerChannel;
 pub use net::source::SourceAddr;
-pub use net::Socket;
+pub use net::SocketImpl;
 pub use probe::{IcmpPacketType, Probe, ProbeStatus};
 pub use tracer::{Tracer, TracerRound};

--- a/src/tracing/net.rs
+++ b/src/tracing/net.rs
@@ -20,6 +20,9 @@ pub mod channel;
 /// Determine the source address.
 pub mod source;
 
+/// The platform specific socket type.
+pub use platform::Socket;
+
 /// An abstraction over a network interface for tracing.
 pub trait Network {
     /// Send a `Probe`.

--- a/src/tracing/net.rs
+++ b/src/tracing/net.rs
@@ -21,7 +21,7 @@ pub mod channel;
 pub mod source;
 
 /// The platform specific socket type.
-pub use platform::Socket;
+pub use platform::SocketImpl;
 
 /// An abstraction over a network interface for tracing.
 pub trait Network {

--- a/src/tracing/net/ipv4.rs
+++ b/src/tracing/net/ipv4.rs
@@ -2,7 +2,7 @@ use crate::tracing::error::TracerError::AddressNotAvailable;
 use crate::tracing::error::{IoResult, TraceResult, TracerError};
 use crate::tracing::net::channel::MAX_PACKET_SIZE;
 use crate::tracing::net::platform;
-use crate::tracing::net::socket::TracerSocket;
+use crate::tracing::net::socket::Socket;
 use crate::tracing::packet::checksum::{icmp_ipv4_checksum, udp_ipv4_checksum};
 use crate::tracing::packet::icmpv4::destination_unreachable::DestinationUnreachablePacket;
 use crate::tracing::packet::icmpv4::echo_reply::EchoReplyPacket;
@@ -44,7 +44,7 @@ const DONT_FRAGMENT: u16 = 0x4000;
 
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip(icmp_send_socket, probe))]
-pub fn dispatch_icmp_probe<S: TracerSocket>(
+pub fn dispatch_icmp_probe<S: Socket>(
     icmp_send_socket: &mut S,
     probe: Probe,
     src_addr: Ipv4Addr,
@@ -83,7 +83,7 @@ pub fn dispatch_icmp_probe<S: TracerSocket>(
 
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip(raw_send_socket, probe))]
-pub fn dispatch_udp_probe<S: TracerSocket>(
+pub fn dispatch_udp_probe<S: Socket>(
     raw_send_socket: &mut S,
     probe: Probe,
     src_addr: Ipv4Addr,
@@ -145,7 +145,7 @@ fn swap_checksum_and_payload(udp: &mut UdpPacket<'_>) {
 }
 
 #[instrument(skip(probe))]
-pub fn dispatch_tcp_probe<S: TracerSocket>(
+pub fn dispatch_tcp_probe<S: Socket>(
     probe: Probe,
     src_addr: Ipv4Addr,
     dest_addr: Ipv4Addr,
@@ -183,7 +183,7 @@ pub fn dispatch_tcp_probe<S: TracerSocket>(
 }
 
 #[instrument(skip(recv_socket))]
-pub fn recv_icmp_probe<S: TracerSocket>(
+pub fn recv_icmp_probe<S: Socket>(
     recv_socket: &mut S,
     protocol: TracerProtocol,
 ) -> TraceResult<Option<ProbeResponse>> {
@@ -201,7 +201,7 @@ pub fn recv_icmp_probe<S: TracerSocket>(
 }
 
 #[instrument(skip(tcp_socket))]
-pub fn recv_tcp_socket<S: TracerSocket>(
+pub fn recv_tcp_socket<S: Socket>(
     tcp_socket: &S,
     sequence: Sequence,
     dest_addr: IpAddr,

--- a/src/tracing/net/ipv6.rs
+++ b/src/tracing/net/ipv6.rs
@@ -2,7 +2,7 @@ use crate::tracing::error::TracerError::AddressNotAvailable;
 use crate::tracing::error::{IoResult, TraceResult, TracerError};
 use crate::tracing::net::channel::MAX_PACKET_SIZE;
 use crate::tracing::net::platform;
-use crate::tracing::net::socket::TracerSocket;
+use crate::tracing::net::socket::Socket;
 use crate::tracing::packet::checksum::{icmp_ipv6_checksum, udp_ipv6_checksum};
 use crate::tracing::packet::icmpv6::destination_unreachable::DestinationUnreachablePacket;
 use crate::tracing::packet::icmpv6::echo_reply::EchoReplyPacket;
@@ -37,7 +37,7 @@ const MAX_ICMP_PACKET_BUF: usize = MAX_PACKET_SIZE - Ipv6Packet::minimum_packet_
 const MAX_ICMP_PAYLOAD_BUF: usize = MAX_ICMP_PACKET_BUF - IcmpPacket::minimum_packet_size();
 
 #[instrument(skip(icmp_send_socket, probe))]
-pub fn dispatch_icmp_probe<S: TracerSocket>(
+pub fn dispatch_icmp_probe<S: Socket>(
     icmp_send_socket: &mut S,
     probe: Probe,
     src_addr: Ipv6Addr,
@@ -67,7 +67,7 @@ pub fn dispatch_icmp_probe<S: TracerSocket>(
 
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip(udp_send_socket, probe))]
-pub fn dispatch_udp_probe<S: TracerSocket>(
+pub fn dispatch_udp_probe<S: Socket>(
     udp_send_socket: &mut S,
     probe: Probe,
     src_addr: Ipv6Addr,
@@ -99,7 +99,7 @@ pub fn dispatch_udp_probe<S: TracerSocket>(
 }
 
 #[instrument(skip(probe))]
-pub fn dispatch_tcp_probe<S: TracerSocket>(
+pub fn dispatch_tcp_probe<S: Socket>(
     probe: Probe,
     src_addr: Ipv6Addr,
     dest_addr: Ipv6Addr,
@@ -135,7 +135,7 @@ pub fn dispatch_tcp_probe<S: TracerSocket>(
 }
 
 #[instrument(skip(recv_socket))]
-pub fn recv_icmp_probe<S: TracerSocket>(
+pub fn recv_icmp_probe<S: Socket>(
     recv_socket: &mut S,
     protocol: TracerProtocol,
 ) -> TraceResult<Option<ProbeResponse>> {
@@ -157,7 +157,7 @@ pub fn recv_icmp_probe<S: TracerSocket>(
 }
 
 #[instrument(skip(tcp_socket))]
-pub fn recv_tcp_socket<S: TracerSocket>(
+pub fn recv_tcp_socket<S: Socket>(
     tcp_socket: &S,
     sequence: Sequence,
     dest_addr: IpAddr,

--- a/src/tracing/net/socket.rs
+++ b/src/tracing/net/socket.rs
@@ -2,7 +2,7 @@ use crate::tracing::error::IoResult as Result;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::Duration;
 
-pub trait TracerSocket
+pub trait Socket
 where
     Self: Sized,
 {

--- a/src/tracing/net/source.rs
+++ b/src/tracing/net/source.rs
@@ -1,8 +1,8 @@
 use crate::tracing::error::TraceResult;
 use crate::tracing::error::TracerError::InvalidSourceAddr;
 use crate::tracing::net::platform;
-use crate::tracing::net::platform::Socket;
-use crate::tracing::net::socket::TracerSocket as _;
+use crate::tracing::net::platform::SocketImpl;
+use crate::tracing::net::socket::Socket as _;
 use crate::tracing::types::Port;
 use crate::tracing::PortDirection;
 use std::net::{IpAddr, SocketAddr};
@@ -42,10 +42,10 @@ impl SourceAddr {
 }
 
 /// Create a socket suitable for a given address.
-pub fn udp_socket_for_addr_family(addr: IpAddr) -> TraceResult<Socket> {
+pub fn udp_socket_for_addr_family(addr: IpAddr) -> TraceResult<SocketImpl> {
     Ok(match addr {
-        IpAddr::V4(_) => Socket::new_udp_dgram_socket_ipv4(),
-        IpAddr::V6(_) => Socket::new_udp_dgram_socket_ipv6(),
+        IpAddr::V4(_) => SocketImpl::new_udp_dgram_socket_ipv4(),
+        IpAddr::V6(_) => SocketImpl::new_udp_dgram_socket_ipv6(),
     }?)
 }
 


### PR DESCRIPTION
Make the net code generic of `S: Socket` so we can mock out the socket impl for better testing