### PR TITLE
feat(net): add `Paris` ECMP strategy support for `Ipv6/UDP` (#749)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -444,12 +444,7 @@ impl TryFrom<(Args, &Platform)> for TrippyConfig {
         };
         let multipath_strategy = match (multipath_strategy_cfg, addr_family) {
             (MultipathStrategyConfig::Classic, _) => Ok(MultipathStrategy::Classic),
-            (MultipathStrategyConfig::Paris, TracerAddrFamily::Ipv4) => {
-                Ok(MultipathStrategy::Paris)
-            }
-            (MultipathStrategyConfig::Paris, TracerAddrFamily::Ipv6) => Err(anyhow!(
-                "Paris multipath strategy not implemented for IPv6 yet!"
-            )),
+            (MultipathStrategyConfig::Paris, _) => Ok(MultipathStrategy::Paris),
             (MultipathStrategyConfig::Dublin, TracerAddrFamily::Ipv4) => {
                 Ok(MultipathStrategy::Dublin)
             }

--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -82,7 +82,7 @@ pub struct Args {
     #[arg(long)]
     pub initial_sequence: Option<u16>,
 
-    /// The Equal-cost Multi-Path routing strategy (IPv4/UDP only) [default: classic]
+    /// The Equal-cost Multi-Path routing strategy (UDP only) [default: classic]
     #[arg(value_enum, short = 'R', long)]
     pub multipath_strategy: Option<MultipathStrategyConfig>,
 

--- a/src/tracing/net/channel.rs
+++ b/src/tracing/net/channel.rs
@@ -158,6 +158,7 @@ impl<S: Socket> TracerChannel<S> {
                     self.privilege_mode,
                     self.packet_size,
                     self.payload_pattern,
+                    self.multipath_strategy,
                 )
             }
             _ => unreachable!(),

--- a/trippy-config-sample.toml
+++ b/trippy-config-sample.toml
@@ -121,7 +121,7 @@ grace-duration = "100ms"
 # The initial sequence number [default: 33000]
 initial-sequence = 33000
 
-# The Equal-cost Multi-Path routing strategy (IPv4/UDP only)
+# The Equal-cost Multi-Path routing strategy (UDP only)
 #
 # Allowed value are:
 #   classic - The src or dest port is used to store the sequence number [default]


### PR DESCRIPTION
Closes #749 