### PR TITLE
Add icmp argument to allow shortcut for base protocol

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -435,10 +435,10 @@ impl TryFrom<(Args, &Platform)> for TrippyConfig {
             constants::DEFAULT_REPORT_CYCLES,
         );
         let geoip_mmdb_file = cfg_layer_opt(args.geoip_mmdb_file, cfg_file_tui.geoip_mmdb_file);
-        let protocol = match (args.udp, args.tcp, protocol) {
-            (false, false, Protocol::Icmp) => TracerProtocol::Icmp,
-            (false, false, Protocol::Udp) | (true, _, _) => TracerProtocol::Udp,
-            (false, false, Protocol::Tcp) | (_, true, _) => TracerProtocol::Tcp,
+        let protocol = match (args.udp, args.tcp, args.icmp, protocol) {
+            (false, false, false, Protocol::Udp) | (true, _, _, _) => TracerProtocol::Udp,
+            (false, false, false, Protocol::Tcp) | (_, true, _, _) => TracerProtocol::Tcp,
+            (false, false, false, Protocol::Icmp) | (_, _, true, _) => TracerProtocol::Icmp,
         };
         let read_timeout = humantime::parse_duration(&read_timeout)?;
         let min_round_duration = humantime::parse_duration(&min_round_duration)?;

--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -34,12 +34,31 @@ pub struct Args {
     pub protocol: Option<Protocol>,
 
     /// Trace using the UDP protocol
-    #[arg(long, conflicts_with = "protocol", conflicts_with = "tcp")]
+    #[arg(
+        long,
+        conflicts_with = "protocol",
+        conflicts_with = "tcp",
+        conflicts_with = "icmp"
+    )]
     pub udp: bool,
 
     /// Trace using the TCP protocol
-    #[arg(long, conflicts_with = "protocol", conflicts_with = "udp")]
+    #[arg(
+        long,
+        conflicts_with = "protocol",
+        conflicts_with = "udp",
+        conflicts_with = "icmp"
+    )]
     pub tcp: bool,
+
+    /// Trace using the ICMP protocol
+    #[arg(
+        long,
+        conflicts_with = "protocol",
+        conflicts_with = "udp",
+        conflicts_with = "tcp"
+    )]
+    pub icmp: bool,
 
     /// Use IPv4 only
     #[arg(short = '4', long, conflicts_with = "ipv6")]


### PR DESCRIPTION
The following tests for the mentioned use case:
1) Change protocol in the config file to non default tcp or udp.
2) Run trippy with shortcut --icmp
Results:
Config: protocol=icmp(v4, unprivileged) as-info=n/a details=off max-hosts=auto 

This passed the basic use case please post comments if others should be run

Closes #649 