### PR TITLE
Refactor Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
-FROM rust:1.74 as build-env
-RUN rustup target add x86_64-unknown-linux-musl
-WORKDIR /app
-COPY Cargo.toml /app
-COPY Cargo.lock /app
-RUN mkdir /app/src
-RUN echo "fn main() {}" > /app/src/main.rs
-RUN cargo build --release --target=x86_64-unknown-linux-musl
-COPY src /app/src
-COPY trippy-config-sample.toml /app
-COPY README.md /app
-COPY LICENSE /app
-RUN cargo build --release --target=x86_64-unknown-linux-musl
+FROM alpine@sha256:13b7e62e8df80264dbb747995705a986aa530415763a6c58f84a3ca8af9a5bcd as build-env
 
-FROM alpine
-RUN apk update && apk add ncurses
-COPY --from=build-env /app/target/x86_64-unknown-linux-musl/release/trip /
-ENTRYPOINT [ "./trip" ]
+RUN apk add --no-cache \
+    curl=8.5.0-r0 \
+    build-base=0.5-r3 \
+    --repository=https://dl-cdn.alpinelinux.org/alpine/v3.19/main
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+ADD ./ /app
+
+RUN source "$HOME/.cargo/env" && cd /app && cargo build --release
+
+FROM alpine@sha256:13b7e62e8df80264dbb747995705a986aa530415763a6c58f84a3ca8af9a5bcd
+
+RUN apk add --no-cache ncurses=6.4_p20231125-r0 --repository=https://dl-cdn.alpinelinux.org/alpine/v3.19/main
+
+COPY --from=build-env /app/target/release/trip /
+
+ENTRYPOINT ["./trip"]


### PR DESCRIPTION
1. Use alpine image for build to have musl by default as needed for final image
2. Use fixed version for both image and packages, that are known to work until a new version is needed (rust installer is the exception)
3. Use digest when using a docker image since tags can be overwritten
4. Install rust through official installer to take care of adding necessary architecture depending on the system used for building trippy (x86_64, arm, etc)
5. Add whole contents of the repository in one go instead of file by file
6. Run cargo build --release without architecture specified for anyone not running x86_64 to have a working trippy