### PR TITLE
feat: Allow Custom Columns TUI

### DIFF
--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -161,6 +161,10 @@ pub struct Args {
     #[arg(value_enum, long)]
     pub tui_as_mode: Option<AsMode>,
 
+    /// Custom columns to be displayed in the TUI hops table [default: HOLSRAVBWDT]
+    #[arg(long)]
+    pub tui_custom_columns: Option<String>,
+
     /// How to render ICMP extensions [default: off]
     #[arg(value_enum, long)]
     pub tui_icmp_extension_mode: Option<IcmpExtensionMode>,

--- a/src/config/columns.rs
+++ b/src/config/columns.rs
@@ -1,0 +1,207 @@
+use anyhow::anyhow;
+use itertools::Itertools;
+use std::collections::HashSet;
+use std::fmt::{Display, Formatter};
+
+/// The columns to display in the hops table of the TUI.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct TuiColumns(pub Vec<TuiColumn>);
+
+impl TryFrom<&str> for TuiColumns {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Ok(Self(
+            value
+                .chars()
+                .map(TuiColumn::try_from)
+                .collect::<Result<Vec<_>, Self::Error>>()?,
+        ))
+    }
+}
+
+impl Default for TuiColumns {
+    fn default() -> Self {
+        Self::try_from(super::constants::DEFAULT_CUSTOM_COLUMNS).expect("custom columns")
+    }
+}
+
+impl TuiColumns {
+    /// Validate the columns.
+    ///
+    /// Returns any duplicate columns.
+    pub fn find_duplicates(&self) -> Vec<String> {
+        let (_, duplicates) = self.0.iter().fold(
+            (HashSet::<TuiColumn>::new(), Vec::new()),
+            |(mut all, mut dups), column| {
+                if all.iter().contains(column) {
+                    dups.push(column.to_string());
+                } else {
+                    all.insert(*column);
+                }
+                (all, dups)
+            },
+        );
+        duplicates
+    }
+}
+
+/// A TUI hops table column.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum TuiColumn {
+    /// The ttl for a hop.
+    Ttl,
+    /// The hostname for a hostname.
+    Host,
+    /// The packet loss % for a hop.
+    LossPct,
+    /// The number of probes sent for a hop.
+    Sent,
+    /// The number of responses received for a hop.
+    Received,
+    /// The last RTT for a hop.
+    Last,
+    /// The rolling average RTT for a hop.
+    Average,
+    /// The best RTT for a hop.
+    Best,
+    /// The worst RTT for a hop.
+    Worst,
+    /// The stddev of RTT for a hop.
+    StdDev,
+    /// The status of a hop.
+    Status,
+}
+
+impl TryFrom<char> for TuiColumn {
+    type Error = anyhow::Error;
+
+    fn try_from(value: char) -> Result<Self, Self::Error> {
+        match value.to_ascii_lowercase() {
+            'h' => Ok(Self::Ttl),
+            'o' => Ok(Self::Host),
+            'l' => Ok(Self::LossPct),
+            's' => Ok(Self::Sent),
+            'r' => Ok(Self::Received),
+            'a' => Ok(Self::Last),
+            'v' => Ok(Self::Average),
+            'b' => Ok(Self::Best),
+            'w' => Ok(Self::Worst),
+            'd' => Ok(Self::StdDev),
+            't' => Ok(Self::Status),
+            c => Err(anyhow!(format!("unknown column code: {c}"))),
+        }
+    }
+}
+
+impl Display for TuiColumn {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ttl => write!(f, "h"),
+            Self::Host => write!(f, "o"),
+            Self::LossPct => write!(f, "l"),
+            Self::Sent => write!(f, "s"),
+            Self::Received => write!(f, "r"),
+            Self::Last => write!(f, "a"),
+            Self::Average => write!(f, "v"),
+            Self::Best => write!(f, "b"),
+            Self::Worst => write!(f, "w"),
+            Self::StdDev => write!(f, "d"),
+            Self::Status => write!(f, "t"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    ///Test for expected column matches to characters
+    #[test_case('h', TuiColumn::Ttl)]
+    #[test_case('o', TuiColumn::Host)]
+    #[test_case('l', TuiColumn::LossPct)]
+    #[test_case('s', TuiColumn::Sent)]
+    #[test_case('r', TuiColumn::Received)]
+    #[test_case('a', TuiColumn::Last)]
+    #[test_case('v', TuiColumn::Average)]
+    #[test_case('b', TuiColumn::Best)]
+    #[test_case('w', TuiColumn::Worst)]
+    #[test_case('d', TuiColumn::StdDev)]
+    #[test_case('t', TuiColumn::Status)]
+    fn test_try_from_char_for_tui_column(c: char, t: TuiColumn) {
+        assert_eq!(TuiColumn::try_from(c).unwrap(), t);
+    }
+
+    ///Negative test for invalid characters
+    #[test_case('x' ; "invalid x")]
+    #[test_case('z' ; "invalid z")]
+    fn test_try_invalid_char_for_tui_column(c: char) {
+        // Negative test for an unknown character
+        assert!(TuiColumn::try_from(c).is_err());
+    }
+
+    ///Test for TuiColumn type match of Display
+    #[test_case(TuiColumn::Ttl, "h")]
+    #[test_case(TuiColumn::Host, "o")]
+    #[test_case(TuiColumn::LossPct, "l")]
+    #[test_case(TuiColumn::Sent, "s")]
+    #[test_case(TuiColumn::Received, "r")]
+    #[test_case(TuiColumn::Last, "a")]
+    #[test_case(TuiColumn::Average, "v")]
+    #[test_case(TuiColumn::Best, "b")]
+    #[test_case(TuiColumn::Worst, "w")]
+    #[test_case(TuiColumn::StdDev, "d")]
+    #[test_case(TuiColumn::Status, "t")]
+    fn test_display_formatting_for_tui_column(t: TuiColumn, letter: &'static str) {
+        assert_eq!(format!("{t}"), letter);
+    }
+
+    #[test]
+    fn test_try_from_str_for_tui_columns() {
+        let valid_input = "hol";
+        let tui_columns = TuiColumns::try_from(valid_input).unwrap();
+        assert_eq!(
+            tui_columns,
+            TuiColumns(vec![TuiColumn::Ttl, TuiColumn::Host, TuiColumn::LossPct])
+        );
+
+        // Test for invalid characters in the input
+        let invalid_input = "xyz";
+        assert!(TuiColumns::try_from(invalid_input).is_err());
+    }
+
+    #[test]
+    fn test_default_for_tui_columns() {
+        let default_columns = TuiColumns::default();
+        assert_eq!(
+            default_columns,
+            TuiColumns(vec![
+                TuiColumn::Ttl,
+                TuiColumn::Host,
+                TuiColumn::LossPct,
+                TuiColumn::Sent,
+                TuiColumn::Received,
+                TuiColumn::Last,
+                TuiColumn::Average,
+                TuiColumn::Best,
+                TuiColumn::Worst,
+                TuiColumn::StdDev,
+                TuiColumn::Status
+            ])
+        );
+    }
+
+    #[test]
+    fn test_find_duplicates_for_tui_columns() {
+        let columns_with_duplicates = TuiColumns(vec![
+            TuiColumn::Ttl,
+            TuiColumn::Host,
+            TuiColumn::LossPct,
+            TuiColumn::Host, // Duplicate
+        ]);
+
+        let duplicates = columns_with_duplicates.find_duplicates();
+        assert_eq!(duplicates, vec!["o".to_string()]);
+    }
+}

--- a/src/config/constants.rs
+++ b/src/config/constants.rs
@@ -85,6 +85,9 @@ pub const DEFAULT_TUI_PRESERVE_SCREEN: bool = false;
 /// The default value for `tui-as-mode`.
 pub const DEFAULT_TUI_AS_MODE: AsMode = AsMode::Asn;
 
+/// The default value for `tui-custom-columns`.
+pub const DEFAULT_CUSTOM_COLUMNS: &str = "HOLSRAVBWDT";
+
 /// The default value for `tui-icmp-extension-mode`.
 pub const DEFAULT_TUI_ICMP_EXTENSION_MODE: IcmpExtensionMode = IcmpExtensionMode::Off;
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -223,6 +223,7 @@ pub struct ConfigTui {
     pub tui_geoip_mode: Option<GeoIpMode>,
     pub tui_max_addrs: Option<u8>,
     pub geoip_mmdb_file: Option<String>,
+    pub tui_custom_columns: Option<String>,
 }
 
 impl Default for ConfigTui {
@@ -235,6 +236,7 @@ impl Default for ConfigTui {
             tui_privacy_max_ttl: Some(super::constants::DEFAULT_TUI_PRIVACY_MAX_TTL),
             tui_address_mode: Some(super::constants::DEFAULT_TUI_ADDRESS_MODE),
             tui_as_mode: Some(super::constants::DEFAULT_TUI_AS_MODE),
+            tui_custom_columns: Some(String::from(super::constants::DEFAULT_CUSTOM_COLUMNS)),
             tui_icmp_extension_mode: Some(super::constants::DEFAULT_TUI_ICMP_EXTENSION_MODE),
             tui_geoip_mode: Some(super::constants::DEFAULT_TUI_GEOIP_MODE),
             tui_max_addrs: Some(super::constants::DEFAULT_TUI_MAX_ADDRS),

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -18,6 +18,7 @@ use trippy::dns::DnsResolver;
 use tui_app::TuiApp;
 
 mod binding;
+mod columns;
 mod config;
 mod render;
 mod theme;

--- a/src/frontend/columns.rs
+++ b/src/frontend/columns.rs
@@ -1,0 +1,229 @@
+use crate::config::{TuiColumn, TuiColumns};
+use std::fmt::{Display, Formatter};
+
+/// The columns to display in the hops table of the TUI.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Columns(pub Vec<Column>);
+
+impl From<TuiColumns> for Columns {
+    fn from(value: TuiColumns) -> Self {
+        Self(value.0.into_iter().map(Column::from).collect())
+    }
+}
+
+///Settings pop-up depends on format macro
+impl Display for Columns {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let output: Vec<char> = self.0.clone().into_iter().map(Column::into).collect();
+        write!(f, "{}", String::from_iter(output))
+    }
+}
+
+/// A TUI hops table column.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Column {
+    /// The ttl for a hop.
+    Ttl,
+    /// The hostname for a hostname.
+    Host,
+    /// The packet loss % for a hop.
+    LossPct,
+    /// The number of probes sent for a hop.
+    Sent,
+    /// The number of responses received for a hop.
+    Received,
+    /// The last RTT for a hop.
+    Last,
+    /// The rolling average RTT for a hop.
+    Average,
+    /// The best RTT for a hop.
+    Best,
+    /// The worst RTT for a hop.
+    Worst,
+    /// The stddev of RTT for a hop.
+    StdDev,
+    /// The status of a hop.
+    Status,
+}
+
+//Output a char for each column type
+impl From<Column> for char {
+    fn from(col_type: Column) -> Self {
+        match col_type {
+            Column::Ttl => 'h',
+            Column::Host => 'o',
+            Column::LossPct => 'l',
+            Column::Sent => 's',
+            Column::Received => 'r',
+            Column::Last => 'a',
+            Column::Average => 'v',
+            Column::Best => 'b',
+            Column::Worst => 'w',
+            Column::StdDev => 'd',
+            Column::Status => 't',
+        }
+    }
+}
+
+impl From<TuiColumn> for Column {
+    fn from(value: TuiColumn) -> Self {
+        match value {
+            TuiColumn::Ttl => Self::Ttl,
+            TuiColumn::Host => Self::Host,
+            TuiColumn::LossPct => Self::LossPct,
+            TuiColumn::Sent => Self::Sent,
+            TuiColumn::Received => Self::Received,
+            TuiColumn::Last => Self::Last,
+            TuiColumn::Average => Self::Average,
+            TuiColumn::Best => Self::Best,
+            TuiColumn::Worst => Self::Worst,
+            TuiColumn::StdDev => Self::StdDev,
+            TuiColumn::Status => Self::Status,
+        }
+    }
+}
+
+impl Display for Column {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ttl => write!(f, "#"),
+            Self::Host => write!(f, "Host"),
+            Self::LossPct => write!(f, "Loss%"),
+            Self::Sent => write!(f, "Snd"),
+            Self::Received => write!(f, "Recv"),
+            Self::Last => write!(f, "Last"),
+            Self::Average => write!(f, "Avg"),
+            Self::Best => write!(f, "Best"),
+            Self::Worst => write!(f, "Wrst"),
+            Self::StdDev => write!(f, "StDev"),
+            Self::Status => write!(f, "Sts"),
+        }
+    }
+}
+
+impl Column {
+    pub fn width_pct(self) -> u16 {
+        #[allow(clippy::match_same_arms)]
+        match self {
+            Self::Ttl => 3,
+            Self::Host => 42,
+            Self::LossPct => 5,
+            Self::Sent => 5,
+            Self::Received => 5,
+            Self::Last => 5,
+            Self::Average => 5,
+            Self::Best => 5,
+            Self::Worst => 5,
+            Self::StdDev => 5,
+            Self::Status => 5,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use crate::{
+        config::{TuiColumn, TuiColumns},
+        frontend::columns::{Column, Columns},
+    };
+
+    #[test]
+    fn test_columns_conversion_from_tui_columns() {
+        let tui_columns = TuiColumns(vec![
+            TuiColumn::Ttl,
+            TuiColumn::Host,
+            TuiColumn::LossPct,
+            TuiColumn::Sent,
+        ]);
+
+        let columns = Columns::from(tui_columns);
+
+        assert_eq!(
+            columns,
+            Columns(vec![
+                Column::Ttl,
+                Column::Host,
+                Column::LossPct,
+                Column::Sent,
+            ])
+        );
+    }
+
+    #[test]
+    fn test_column_conversion_from_tui_column() {
+        let tui_column = TuiColumn::Received;
+        let column = Column::from(tui_column);
+
+        assert_eq!(column, Column::Received);
+    }
+
+    #[test_case(Column::Ttl, "#")]
+    #[test_case(Column::Host, "Host")]
+    #[test_case(Column::LossPct, "Loss%")]
+    #[test_case(Column::Sent, "Snd")]
+    #[test_case(Column::Received, "Recv")]
+    #[test_case(Column::Last, "Last")]
+    #[test_case(Column::Average, "Avg")]
+    #[test_case(Column::Best, "Best")]
+    #[test_case(Column::Worst, "Wrst")]
+    #[test_case(Column::StdDev, "StDev")]
+    #[test_case(Column::Status, "Sts")]
+    fn test_column_display_formatting(c: Column, heading: &'static str) {
+        assert_eq!(format!("{c}"), heading);
+    }
+
+    #[test_case(Column::Ttl, 3)]
+    #[test_case(Column::Host, 42)]
+    #[test_case(Column::LossPct, 5)]
+    fn test_column_width_percentage(column_type: Column, pct: u16) {
+        assert_eq!(column_type.width_pct(), pct);
+    }
+
+    ///Expect to test the Column Into <char> flow
+    #[test]
+    fn test_columns_into_string_short() {
+        let cols = Columns(vec![
+            Column::Ttl,
+            Column::Host,
+            Column::LossPct,
+            Column::Sent,
+        ]);
+        assert_eq!("hols", format!("{cols}"));
+    }
+
+    ///Happy path test for full set of colummns
+    #[test]
+    fn test_columns_into_string_happy_path() {
+        let cols = Columns(vec![
+            Column::Ttl,
+            Column::Host,
+            Column::LossPct,
+            Column::Sent,
+            Column::Received,
+            Column::Last,
+            Column::Average,
+            Column::Best,
+            Column::Worst,
+            Column::StdDev,
+            Column::Status,
+        ]);
+        assert_eq!("holsravbwdt", format!("{cols}"));
+    }
+
+    ///Reverse subset test for subset of colummns
+    #[test]
+    fn test_columns_into_string_reverse_str() {
+        let cols = Columns(vec![
+            Column::Status,
+            Column::Last,
+            Column::StdDev,
+            Column::Worst,
+            Column::Best,
+            Column::Average,
+            Column::Received,
+        ]);
+        assert_eq!("tadwbvr", format!("{cols}"));
+    }
+}

--- a/src/frontend/config.rs
+++ b/src/frontend/config.rs
@@ -1,6 +1,7 @@
-use crate::config::{AddressMode, AsMode, GeoIpMode, TuiTheme};
+use crate::config::{AddressMode, AsMode, GeoIpMode, TuiColumns, TuiTheme};
 use crate::config::{IcmpExtensionMode, TuiBindings};
 use crate::frontend::binding::Bindings;
+use crate::frontend::columns::Columns;
 use crate::frontend::theme::Theme;
 use std::time::Duration;
 
@@ -33,6 +34,8 @@ pub struct TuiConfig {
     pub theme: Theme,
     /// The Tui keyboard bindings.
     pub bindings: Bindings,
+    /// The columns to display in the hops table.
+    pub tui_columns: Columns,
 }
 
 impl TuiConfig {
@@ -51,6 +54,7 @@ impl TuiConfig {
         max_flows: usize,
         tui_theme: TuiTheme,
         tui_bindings: &TuiBindings,
+        tui_columns: &TuiColumns,
     ) -> Self {
         Self {
             refresh_rate,
@@ -66,6 +70,7 @@ impl TuiConfig {
             max_flows,
             theme: Theme::from(tui_theme),
             bindings: Bindings::from(*tui_bindings),
+            tui_columns: Columns::from(tui_columns.clone()),
         }
     }
 }

--- a/src/frontend/render/settings.rs
+++ b/src/frontend/render/settings.rs
@@ -177,6 +177,10 @@ fn format_tui_settings(app: &TuiApp) -> Vec<SettingsItem> {
                 .max_addrs
                 .map_or_else(|| String::from("auto"), |m| m.to_string()),
         ),
+        SettingsItem::new(
+            "tui-custom-columns",
+            format!("{}", app.tui_config.tui_columns),
+        ),
     ]
 }
 
@@ -420,7 +424,7 @@ fn format_theme_settings(app: &TuiApp) -> Vec<SettingsItem> {
 
 /// The name and number of items for each tabs in the setting dialog.
 pub const SETTINGS_TABS: [(&str, usize); 6] = [
-    ("Tui", 9),
+    ("Tui", 10),
     ("Trace", 15),
     ("Dns", 4),
     ("GeoIp", 1),

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,6 +317,7 @@ fn make_tui_config(args: &TrippyConfig) -> TuiConfig {
         args.tui_max_flows,
         args.tui_theme,
         &args.tui_bindings,
+        &args.tui_custom_columns,
     )
 }
 

--- a/trippy-config-sample.toml
+++ b/trippy-config-sample.toml
@@ -216,7 +216,6 @@ dns-timeout = "5s"
 # Only applicable for modes pretty, markdown, csv and json.
 report-cycles = 10
 
-
 #
 # General Tui Configuration.
 #
@@ -241,7 +240,26 @@ tui-address-mode = "host"
 #   name            - Display the AS name
 tui-as-mode = "asn"
 
-# How to render ICMP extensions
+# Custom columns to be displayed in the TUI hops table.
+#
+# Allowed values are:
+#
+#   H - Ttl
+#   O - Hostname
+#   L - Loss %
+#   S - Probes sent
+#   R - Responses received
+#   A - Last RTT
+#   V - Average RTT
+#   B - Best RTT
+#   W - Worst RTT
+#   D - Stddev
+#   T - Status
+#
+# The columns will be shown in the order specified.
+tui-custom-columns = "HOLSRAVBWDT"
+
+# How to render ICMP extensions.
 #
 #   off             - Do not show icmp extensions [default]
 #   mpls            - Show MPLS label(s) only


### PR DESCRIPTION
Added:
Custom columns to TUI interface by either the configuration file or command line option
Calculation of column percentage with 40% constant percentage for hosts column.
Unit tests for TuiColumns and Columns classes 
cargo test frontend::columns
cargo test config::columns

Tests run:
cargo run -- -u --tui-custom-columns="" -m tui freebsd.org
cargo run -- -u -c ./trippy-config-sample.toml -m tui freebsd.org
cargo run -- -u --tui-custom-columns="" -c ./trippy-config-sample.toml -m tui freebsd.org
cargo run -- -u --tui-custom-columns="" -m tui freebsd.org
cargo run -- -u --tui-custom-columns="thobwd" -m tui freebsd.org
