### PR TITLE
feat: default resolve both IPv4 and IPv6 addresses

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,8 @@ pub enum AddressFamily {
     Ipv4,
     /// Internet Protocol V6
     Ipv6,
+    /// Both Internet Protocol V4 or V6
+    Any,
 }
 
 /// The strategy Equal-cost Multi-Path routing strategy.
@@ -496,6 +498,7 @@ impl TrippyConfig {
             .transpose()?;
         let addr_family = match (args.ipv4, args.ipv6, cfg_file_strategy.addr_family) {
             (false, false, None) => addr_family(constants::DEFAULT_ADDRESS_FAMILY),
+            (false, false, Some(AddressFamily::Any)) => addr_family(constants::DEFAULT_ADDRESS_FAMILY),
             (false, false, Some(AddressFamily::Ipv4)) | (true, _, _) => TracerAddrFamily::Ipv4,
             (false, false, Some(AddressFamily::Ipv6)) | (_, true, _) => TracerAddrFamily::Ipv6,
         };
@@ -507,6 +510,9 @@ impl TrippyConfig {
             }
             (MultipathStrategyConfig::Dublin, TracerAddrFamily::Ipv6) => Err(anyhow!(
                 "Dublin multipath strategy not implemented for IPv6 yet!"
+            )),
+            (MultipathStrategyConfig::Dublin, TracerAddrFamily::Any) => Err(anyhow!(
+                "Dublin multipath strategy not implemented for IPv6 yet! You need to force IPv4."
             )),
         }?;
         let port_direction = match (protocol, source_port, target_port, multipath_strategy_cfg) {
@@ -722,6 +728,7 @@ fn addr_family(addr_family: AddressFamily) -> TracerAddrFamily {
     match addr_family {
         AddressFamily::Ipv4 => TracerAddrFamily::Ipv4,
         AddressFamily::Ipv6 => TracerAddrFamily::Ipv6,
+        AddressFamily::Any => TracerAddrFamily::Any,
     }
 }
 

--- a/src/config/constants.rs
+++ b/src/config/constants.rs
@@ -32,7 +32,7 @@ pub const DEFAULT_LOG_FILTER: &str = "trippy=debug";
 pub const DEFAULT_STRATEGY_PROTOCOL: Protocol = Protocol::Icmp;
 
 /// The default value for `addr-family`.
-pub const DEFAULT_ADDRESS_FAMILY: AddressFamily = AddressFamily::Ipv4;
+pub const DEFAULT_ADDRESS_FAMILY: AddressFamily = AddressFamily::Any;
 
 /// The default value for `min-round-duration`.
 pub const DEFAULT_STRATEGY_MIN_ROUND_DURATION: &str = "1s";

--- a/src/dns/lazy_resolver.rs
+++ b/src/dns/lazy_resolver.rs
@@ -34,6 +34,8 @@ pub enum IpAddrFamily {
     Ipv4,
     /// Internet Protocol v6.
     Ipv6,
+    /// Both Internet Protocol V4 or V6
+    Any,
 }
 
 impl Config {
@@ -53,6 +55,16 @@ impl Config {
         Self {
             resolve_method,
             addr_family: IpAddrFamily::Ipv6,
+            timeout,
+        }
+    }
+
+    /// Create an Any IP version `Config`
+    #[must_use]
+    pub fn new_any(resolve_method: ResolveMethod, timeout: Duration) -> Self {
+        Self {
+            resolve_method,
+            addr_family: IpAddrFamily::Any,
             timeout,
         }
     }
@@ -170,6 +182,7 @@ mod inner {
                 options.ip_strategy = match config.addr_family {
                     IpAddrFamily::Ipv4 => LookupIpStrategy::Ipv4Only,
                     IpAddrFamily::Ipv6 => LookupIpStrategy::Ipv6Only,
+                    IpAddrFamily::Any => LookupIpStrategy::default(),
                 };
                 let res = match config.resolve_method {
                     ResolveMethod::Resolv => Resolver::from_system_conf(),
@@ -216,6 +229,8 @@ mod inner {
                             (self.config.addr_family, addr),
                             (IpAddrFamily::Ipv4, IpAddr::V4(_))
                                 | (IpAddrFamily::Ipv6, IpAddr::V6(_))
+                                | (IpAddrFamily::Any, IpAddr::V4(_))
+                                | (IpAddrFamily::Any, IpAddr::V6(_))
                         )
                     })
                     .collect::<Vec<_>>()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,9 @@ fn start_dns_resolver(cfg: &TrippyConfig) -> anyhow::Result<DnsResolver> {
         TracerAddrFamily::Ipv6 => {
             DnsResolver::start(Config::new_ipv6(cfg.dns_resolve_method, cfg.dns_timeout))?
         }
+        TracerAddrFamily::Any => {
+            DnsResolver::start(Config::new_any(cfg.dns_resolve_method, cfg.dns_timeout))?
+        }
     })
 }
 

--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -33,6 +33,8 @@ pub enum TracerAddrFamily {
     Ipv4,
     /// Internet Protocol V6
     Ipv6,
+    /// Both Internet Protocol V4 or V6
+    Any
 }
 
 impl Display for TracerAddrFamily {
@@ -40,6 +42,7 @@ impl Display for TracerAddrFamily {
         match self {
             Self::Ipv4 => write!(f, "v4"),
             Self::Ipv6 => write!(f, "v6"),
+            Self::Any => write!(f, "v4v6"),
         }
     }
 }


### PR DESCRIPTION
This is useful when target host only has a IPv6 address and the user has not forced particular address family.

Fixes: #864