### PR TITLE
feat display jitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -626,6 +626,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe739944a5406424e080edccb6add95685130b9f160d5407c639c7df0c5836b0"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +870,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "iso8601-timestamp"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daa57edc7ad71119e3d501cec542b6c3552881a421ebd61a78c7bf25ebc2eb73"
+dependencies = [
+ "generic-array",
+ "serde",
+ "time",
 ]
 
 [[package]]
@@ -1840,6 +1860,7 @@ dependencies = [
  "humantime",
  "indexmap 2.1.0",
  "ipnetwork",
+ "iso8601-timestamp",
  "itertools",
  "maxminddb",
  "nix",
@@ -1884,6 +1905,12 @@ dependencies = [
  "tokio-util",
  "wintun",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
 tracing-chrome = "0.7.1"
 petgraph = "0.6.4"
 csv = "1.3.0"
+iso8601-timestamp = "0.2.16"
 serde_with = "3.4.0"
 
 # Library dependencies (Linux)

--- a/src/config/columns.rs
+++ b/src/config/columns.rs
@@ -71,6 +71,14 @@ pub enum TuiColumn {
     StdDev,
     /// The status of a hop.
     Status,
+    /// The jitter abs(RTTx-RTTx-1)
+    Jitter,
+    /// The jitter total average
+    Javg,
+    /// The worst or max jitter recorded.
+    Jmax,
+    /// The smoothed jitter reading
+    Jinta,
 }
 
 impl TryFrom<char> for TuiColumn {
@@ -89,6 +97,10 @@ impl TryFrom<char> for TuiColumn {
             'w' => Ok(Self::Worst),
             'd' => Ok(Self::StdDev),
             't' => Ok(Self::Status),
+            'j' => Ok(Self::Jitter),
+            'g' => Ok(Self::Javg),
+            'x' => Ok(Self::Jmax),
+            'i' => Ok(Self::Jinta),
             c => Err(anyhow!(format!("unknown column code: {c}"))),
         }
     }
@@ -108,6 +120,10 @@ impl Display for TuiColumn {
             Self::Worst => write!(f, "w"),
             Self::StdDev => write!(f, "d"),
             Self::Status => write!(f, "t"),
+            Self::Jitter => write!(f, "j"),
+            Self::Javg => write!(f, "g"),
+            Self::Jmax => write!(f, "x"),
+            Self::Jinta => write!(f, "i"),
         }
     }
 }
@@ -134,7 +150,7 @@ mod tests {
     }
 
     ///Negative test for invalid characters
-    #[test_case('x' ; "invalid x")]
+    #[test_case('k' ; "invalid x")]
     #[test_case('z' ; "invalid z")]
     fn test_try_invalid_char_for_tui_column(c: char) {
         // Negative test for an unknown character

--- a/src/report/types.rs
+++ b/src/report/types.rs
@@ -35,6 +35,14 @@ pub struct Hop {
     pub worst: f64,
     #[serde(serialize_with = "fixed_width")]
     pub stddev: f64,
+    #[serde(serialize_with = "fixed_width")]
+    pub jitter: f64,
+    #[serde(serialize_with = "fixed_width")]
+    pub javg: f64,
+    #[serde(serialize_with = "fixed_width")]
+    pub jmax: f64,
+    #[serde(serialize_with = "fixed_width")]
+    pub jinta: f64,
 }
 
 impl<R: Resolver> From<(&backend::trace::Hop, &R)> for Hop {
@@ -53,6 +61,10 @@ impl<R: Resolver> From<(&backend::trace::Hop, &R)> for Hop {
             best: value.best_ms().unwrap_or_default(),
             worst: value.worst_ms().unwrap_or_default(),
             stddev: value.stddev_ms(),
+            jitter: value.jitter_ms().unwrap_or_default(),
+            javg: value.javg_ms().unwrap_or_default(),
+            jmax: value.jmax_ms().unwrap_or_default(),
+            jinta: value.jinta().unwrap_or_default(),
         }
     }
 }
@@ -72,7 +84,6 @@ impl<'a, R: Resolver, I: Iterator<Item = &'a IpAddr>> From<(I, &R)> for Hosts {
         )
     }
 }
-
 impl Display for Hosts {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0.iter().format(", "))

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -4,8 +4,8 @@ mod constants;
 mod error;
 mod net;
 mod probe;
-mod tracer;
-mod types;
+pub mod tracer;
+pub mod types;
 
 /// Packet wire formats.
 pub mod packet;

--- a/tests/data/base_line.json
+++ b/tests/data/base_line.json
@@ -1,0 +1,27 @@
+[{
+    "sequence": 1,
+    "identifier": 1,
+    "src_port": 80,
+    "dest_port": 80,
+    "ttl": 1,
+    "round": 1,
+    "sent": "2023-01-01T12:01:55.100",
+    "status": "Complete",
+    "host": "10.1.0.2",
+    "received": "2023-01-01T12:01:55.400",
+    "icmp_packet_type": null,
+    "extensions": null
+  },{
+    "sequence": 2,
+    "identifier": 1,
+    "src_port": 80,
+    "dest_port": 80,
+    "ttl": 1,
+    "round": 1,
+    "sent": "2023-01-01T12:01:56.100",
+    "status": "Complete",
+    "host": "10.1.0.2",
+    "received": "2023-01-01T12:01:56.800",
+    "icmp_packet_type": null,
+    "extensions": null
+  }]

--- a/tests/data/jinta_1hop.json
+++ b/tests/data/jinta_1hop.json
@@ -1,0 +1,53 @@
+[{
+    "sequence": 1,
+    "identifier": 1,
+    "src_port": 80,
+    "dest_port": 80,
+    "ttl": 1,
+    "round": 1,
+    "sent": "2023-01-01T12:01:55.100",
+    "status": "Complete",
+    "host": "10.1.0.2",
+    "received": "2023-01-01T12:01:55.300",
+    "icmp_packet_type": null,
+    "extensions": null
+  },{
+    "sequence": 2,
+    "identifier": 1,
+    "src_port": 80,
+    "dest_port": 80,
+    "ttl": 1,
+    "round": 1,
+    "sent": "2023-01-01T12:01:56.100",
+    "status": "Complete",
+    "host": "10.1.0.2",
+    "received": "2023-01-01T12:01:56.200",
+    "icmp_packet_type": null,
+    "extensions": null
+  },{
+    "sequence": 3,
+    "identifier": 1,
+    "src_port": 80,
+    "dest_port": 80,
+    "ttl": 1,
+    "round": 1,
+    "sent": "2023-01-01T12:01:57.100",
+    "status": "Complete",
+    "host": "10.1.0.2",
+    "received": "2023-01-01T12:01:57.250",
+    "icmp_packet_type": null,
+    "extensions": null
+  },{
+    "sequence": 4,
+    "identifier": 1,
+    "src_port": 80,
+    "dest_port": 80,
+    "ttl": 1,
+    "round": 1,
+    "sent": "2023-01-01T12:01:58.000",
+    "status": "Complete",
+    "host": "10.1.0.2",
+    "received": "2023-01-01T12:01:59.001",
+    "icmp_packet_type": null,
+    "extensions": null
+  }]

--- a/tests/expected/jinta_1hop.json
+++ b/tests/expected/jinta_1hop.json
@@ -1,0 +1,13 @@
+{
+    "total_sent": 4,
+    "total_recv": 4,
+    "last": 1001,
+    "best": 300,
+    "worst": 700,
+    "mean": 0.0,
+    "m2": 0.0,
+    "jitter": 851,
+    "javg": 300.25,
+    "jmax": 851,
+    "jinta": 1148.74
+}


### PR DESCRIPTION
The branch is currently a WIP to get feedback on Jitter calculations and display.

Know issues:
The display will overflow if all the columns are displayed; though as an interim fix, the Constraint::Min is used.  
Jitter columns will only show using tui-custom-columns 
Jitter columns display in json & tui mode's only.  Json was added for saving test results for comparison to mtr.

Closes #39 