### PR TITLE
build: reinstate macos and windows clippy CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,14 +62,33 @@ jobs:
       - run: cargo fmt --all -- --check
 
   clippy:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build:
+          - linux-stable
+          - macos-stable
+          - windows-stable
+        include:
+          - build: linux-stable
+            os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            rust: stable
+          - build: macos-stable
+            os: macos-latest
+            target: x86_64-apple-darwin
+            rust: stable
+          - build: windows-stable
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            rust: stable
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           components: clippy
-      - run: cargo clippy --workspace --all-features --tests -- -Dwarnings
+      - run: cargo clippy --workspace --all-features --target ${{ matrix.target }} --tests -- -Dwarnings
 
   cargo-deny:
     runs-on: ubuntu-22.04

--- a/src/tracing/net/platform/windows.rs
+++ b/src/tracing/net/platform/windows.rs
@@ -113,7 +113,7 @@ pub struct SocketImpl {
     bytes_read: u32,
 }
 
-#[allow(clippy::cast_possible_wrap)]
+#[allow(clippy::cast_possible_wrap, clippy::redundant_closure_call)]
 impl SocketImpl {
     fn startup() -> IoResult<()> {
         let mut wsa_data = Self::new_wsa_data();
@@ -293,6 +293,7 @@ impl SocketImpl {
     }
 }
 
+#[allow(clippy::redundant_closure_call)]
 impl Drop for SocketImpl {
     fn drop(&mut self) {
         self.close().unwrap_or_default();
@@ -302,7 +303,7 @@ impl Drop for SocketImpl {
     }
 }
 
-#[allow(clippy::cast_possible_wrap)]
+#[allow(clippy::cast_possible_wrap, clippy::redundant_closure_call)]
 impl Socket for SocketImpl {
     #[instrument]
     fn new_icmp_send_socket_ipv4(raw: bool) -> IoResult<Self> {
@@ -599,7 +600,7 @@ impl Socket for SocketImpl {
 /// NOTE under Windows, we cannot use a bind connect/getsockname as "If the socket
 /// is using a connectionless protocol, the address may not be available until I/O
 /// occurs on the socket."  We use `SIO_ROUTING_INTERFACE_QUERY` instead.
-#[allow(clippy::cast_sign_loss)]
+#[allow(clippy::cast_sign_loss, clippy::redundant_closure_call)]
 #[instrument]
 fn routing_interface_query(target: IpAddr) -> TraceResult<IpAddr> {
     let src: *mut c_void = [0; 1024].as_mut_ptr().cast();
@@ -840,7 +841,7 @@ mod adapter {
             Self {
                 next,
                 // tie the lifetime of this iterator to the lifetime of the `Adapters`
-                _data: PhantomData::default(),
+                _data: PhantomData,
             }
         }
     }


### PR DESCRIPTION
was previously removed in cbc2f31a931ef2eb9dd5ac48660c9ced14227355 but unclear why.