### PR TITLE
feat display jitter values

### DIFF
--- a/src/config/columns.rs
+++ b/src/config/columns.rs
@@ -71,6 +71,14 @@ pub enum TuiColumn {
     StdDev,
     /// The status of a hop.
     Status,
+    /// The jitter abs(RTTx-RTTx-1)
+    Jitter,
+    /// The jitter total average
+    Javg,
+    /// The worst or max jitter recorded.
+    Jmax,
+    /// The smoothed jitter reading
+    Jinta,
 }
 
 impl TryFrom<char> for TuiColumn {
@@ -89,6 +97,10 @@ impl TryFrom<char> for TuiColumn {
             'w' => Ok(Self::Worst),
             'd' => Ok(Self::StdDev),
             't' => Ok(Self::Status),
+            'j' => Ok(Self::Jitter),
+            'g' => Ok(Self::Javg),
+            'x' => Ok(Self::Jmax),
+            'i' => Ok(Self::Jinta),
             c => Err(anyhow!(format!("unknown column code: {c}"))),
         }
     }
@@ -108,6 +120,10 @@ impl Display for TuiColumn {
             Self::Worst => write!(f, "w"),
             Self::StdDev => write!(f, "d"),
             Self::Status => write!(f, "t"),
+            Self::Jitter => write!(f, "j"),
+            Self::Javg => write!(f, "g"),
+            Self::Jmax => write!(f, "x"),
+            Self::Jinta => write!(f, "i"),
         }
     }
 }
@@ -134,7 +150,7 @@ mod tests {
     }
 
     ///Negative test for invalid characters
-    #[test_case('x' ; "invalid x")]
+    #[test_case('k' ; "invalid x")]
     #[test_case('z' ; "invalid z")]
     fn test_try_invalid_char_for_tui_column(c: char) {
         // Negative test for an unknown character

--- a/src/frontend/columns.rs
+++ b/src/frontend/columns.rs
@@ -8,13 +8,6 @@ pub struct Columns(pub Vec<Column>);
 
 impl Columns {
     /// Column width constraints.
-    ///
-    /// All columns are returned as `Constraint::Min(width)`.
-    ///
-    /// For `Fixed(n)` columns the width is as specified in `n`.
-    /// For `Variable` columns the width is calculated by subtracting the total
-    /// size of all `Fixed` columns from the width of the containing `Rect` and
-    /// dividing by the number of `Variable` columns.
     pub fn constraints(&self, rect: Rect) -> Vec<Constraint> {
         let total_fixed_width = self
             .0
@@ -24,18 +17,12 @@ impl Columns {
                 ColumnWidth::Variable => 0,
             })
             .sum();
-        let variable_width_count = self
-            .0
-            .iter()
-            .filter(|c| matches!(c.width(), ColumnWidth::Variable))
-            .count() as u16;
-        let variable_width =
-            rect.width.saturating_sub(total_fixed_width) / variable_width_count.max(1);
+        let total_variable_width = rect.width.saturating_sub(total_fixed_width);
         self.0
             .iter()
             .map(|c| match c.width() {
                 ColumnWidth::Fixed(width) => Constraint::Min(width),
-                ColumnWidth::Variable => Constraint::Min(variable_width),
+                ColumnWidth::Variable => Constraint::Min(total_variable_width),
             })
             .collect()
     }
@@ -79,6 +66,14 @@ pub enum Column {
     StdDev,
     /// The status of a hop.
     Status,
+    /// The jitter of a hop(RTTx-RTTx-1).
+    Jitter,
+    /// The Average Jitter
+    Javg,
+    /// The worst or max jitter hop RTT
+    Jmax,
+    /// The smoothed jitter reading for a hop
+    Jinta,
 }
 
 impl From<Column> for char {
@@ -95,6 +90,10 @@ impl From<Column> for char {
             Column::Worst => 'w',
             Column::StdDev => 'd',
             Column::Status => 't',
+            Column::Jitter => 'j',
+            Column::Javg => 'g',
+            Column::Jmax => 'x',
+            Column::Jinta => 'i',
         }
     }
 }
@@ -113,6 +112,10 @@ impl From<TuiColumn> for Column {
             TuiColumn::Worst => Self::Worst,
             TuiColumn::StdDev => Self::StdDev,
             TuiColumn::Status => Self::Status,
+            TuiColumn::Jitter => Self::Jitter,
+            TuiColumn::Javg => Self::Javg,
+            TuiColumn::Jmax => Self::Jmax,
+            TuiColumn::Jinta => Self::Jinta,
         }
     }
 }
@@ -131,8 +134,21 @@ impl Display for Column {
             Self::Worst => write!(f, "Wrst"),
             Self::StdDev => write!(f, "StDev"),
             Self::Status => write!(f, "Sts"),
+            Self::Jitter => write!(f, "Jttr"),
+            Self::Javg => write!(f, "Javg"),
+            Self::Jmax => write!(f, "Jmax"),
+            Self::Jinta => write!(f, "Jint"),
         }
     }
+}
+
+/// Table column layout constraints.
+#[derive(Debug, PartialEq)]
+enum ColumnWidth {
+    /// A fixed size column.
+    Fixed(u16),
+    /// A column that will use the remaining space.
+    Variable,
 }
 
 impl Column {
@@ -150,18 +166,13 @@ impl Column {
             Self::Best => ColumnWidth::Fixed(7),
             Self::Worst => ColumnWidth::Fixed(7),
             Self::StdDev => ColumnWidth::Fixed(8),
-            Self::Status => ColumnWidth::Fixed(7),
+            Self::Status => ColumnWidth::Fixed(4),
+            Self::Jitter => ColumnWidth::Fixed(7),
+            Self::Javg => ColumnWidth::Fixed(7),
+            Self::Jmax => ColumnWidth::Fixed(7),
+            Self::Jinta => ColumnWidth::Fixed(7),
         }
     }
-}
-
-/// Table column layout constraints.
-#[derive(Debug, PartialEq)]
-enum ColumnWidth {
-    /// A fixed size column.
-    Fixed(u16),
-    /// A column that will use the remaining space.
-    Variable,
 }
 
 #[cfg(test)]
@@ -229,7 +240,7 @@ mod tests {
         assert_eq!(
             vec![
                 Min(4),
-                Min(11),
+                Min(14),
                 Min(8),
                 Min(7),
                 Min(7),
@@ -238,7 +249,7 @@ mod tests {
                 Min(7),
                 Min(7),
                 Min(8),
-                Min(7)
+                Min(4)
             ],
             constraints
         );

--- a/src/frontend/render/table.rs
+++ b/src/frontend/render/table.rs
@@ -17,7 +17,7 @@ use trippy::tracing::{Extension, Extensions, MplsLabelStackMember, UnknownExtens
 
 /// Render the table of data about the hops.
 ///
-/// For each hop, we show:
+/// For each hop, we show by default:
 ///
 /// - The time-to-live (indexed from 1) at this hop (`#`)
 /// - The host(s) reported at this hop (`Host`)
@@ -30,6 +30,13 @@ use trippy::tracing::{Extension, Extensions, MplsLabelStackMember, UnknownExtens
 /// - The worst round-trip time for all probes at this hop (`Wrst`)
 /// - The standard deviation round-trip time for all probes at this hop (`StDev`)
 /// - The status of this hop (`Sts`)
+///
+/// - Optional columns
+/// - The current jitter i.e. round-trip difference with the last round-trip ('Jttr')
+/// - The average jitter time for all probes at this hop ('Javg')
+/// - The best round-trip jitter tim for all probes at this hop ('Jmax')
+/// - The smoothed jitter value for all probes at this hop ('Jinta')
+/// -
 pub fn render(f: &mut Frame<'_>, app: &mut TuiApp, rect: Rect) {
     let config = &app.tui_config;
     let widths = config.tui_columns.constraints(rect);
@@ -59,8 +66,7 @@ pub fn render(f: &mut Frame<'_>, app: &mut TuiApp, rect: Rect) {
                 .bg(app.tui_config.theme.bg_color)
                 .fg(app.tui_config.theme.text_color),
         )
-        .highlight_style(selected_style)
-        .column_spacing(1);
+        .highlight_style(selected_style);
     f.render_stateful_widget(table, rect, &mut app.table_state);
 }
 
@@ -132,7 +138,7 @@ fn new_cell(
 ) -> Cell<'static> {
     let is_target = app.tracer_data().is_target(hop, app.selected_flow);
     match column {
-        Column::Ttl => render_ttl_cell(hop),
+        Column::Ttl => render_usize_cell(hop.ttl().into()),
         Column::Host => {
             let (host_cell, _) = if is_selected_hop && app.show_hop_details {
                 render_hostname_with_details(app, hop, dns, geoip_lookup, config)
@@ -142,30 +148,27 @@ fn new_cell(
             host_cell
         }
         Column::LossPct => render_loss_pct_cell(hop),
-        Column::Sent => render_total_sent_cell(hop),
-        Column::Received => render_total_recv_cell(hop),
-        Column::Last => render_last_cell(hop),
+        Column::Sent => render_usize_cell(hop.total_sent()),
+        Column::Received => render_usize_cell(hop.total_recv()),
+        Column::Last => render_float_cell(hop.last_ms(), 1),
         Column::Average => render_avg_cell(hop),
-        Column::Best => render_best_cell(hop),
-        Column::Worst => render_worst_cell(hop),
+        Column::Best => render_float_cell(hop.best_ms(), 1),
+        Column::Worst => render_float_cell(hop.worst_ms(), 1),
         Column::StdDev => render_stddev_cell(hop),
         Column::Status => render_status_cell(hop, is_target),
+        Column::Jitter => render_float_cell(hop.jitter_ms(), 1),
+        Column::Javg => render_float_cell(hop.javg_ms(), 1),
+        Column::Jmax => render_float_cell(hop.jmax_ms(), 1),
+        Column::Jinta => render_float_cell(hop.jinta(), 1),
     }
 }
-fn render_ttl_cell(hop: &Hop) -> Cell<'static> {
-    Cell::from(format!("{}", hop.ttl()))
+
+fn render_usize_cell(value: usize) -> Cell<'static> {
+    Cell::from(format!("{value}"))
 }
 
 fn render_loss_pct_cell(hop: &Hop) -> Cell<'static> {
     Cell::from(format!("{:.1}%", hop.loss_pct()))
-}
-
-fn render_total_sent_cell(hop: &Hop) -> Cell<'static> {
-    Cell::from(format!("{}", hop.total_sent()))
-}
-
-fn render_total_recv_cell(hop: &Hop) -> Cell<'static> {
-    Cell::from(format!("{}", hop.total_recv()))
 }
 
 fn render_avg_cell(hop: &Hop) -> Cell<'static> {
@@ -176,36 +179,16 @@ fn render_avg_cell(hop: &Hop) -> Cell<'static> {
     })
 }
 
-fn render_last_cell(hop: &Hop) -> Cell<'static> {
-    Cell::from(
-        hop.last_ms()
-            .map(|last| format!("{last:.1}"))
-            .unwrap_or_default(),
-    )
-}
-
-fn render_best_cell(hop: &Hop) -> Cell<'static> {
-    Cell::from(
-        hop.best_ms()
-            .map(|best| format!("{best:.1}"))
-            .unwrap_or_default(),
-    )
-}
-
-fn render_worst_cell(hop: &Hop) -> Cell<'static> {
-    Cell::from(
-        hop.worst_ms()
-            .map(|worst| format!("{worst:.1}"))
-            .unwrap_or_default(),
-    )
-}
-
 fn render_stddev_cell(hop: &Hop) -> Cell<'static> {
     Cell::from(if hop.total_recv() > 1 {
         format!("{:.1}", hop.stddev_ms())
     } else {
         String::default()
     })
+}
+
+fn render_float_cell(value: Option<f64>, places: usize) -> Cell<'static> {
+    Cell::from(value.map_or(String::new(), |v| format!("{v:.places$}")))
 }
 
 fn render_status_cell(hop: &Hop, is_target: bool) -> Cell<'static> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, rust_2018_idioms)]
 #![allow(
     clippy::module_name_repetitions,
-    clippy::struct_field_names,
+    clippy::redundant_field_names,
     clippy::option_if_let_else,
     clippy::missing_const_for_fn,
     clippy::cast_possible_truncation,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, rust_2018_idioms)]
 #![allow(
     clippy::module_name_repetitions,
-    clippy::struct_field_names,
+    clippy::redundant_field_names,
     clippy::option_if_let_else,
     clippy::missing_const_for_fn,
     clippy::cast_precision_loss,

--- a/src/report/types.rs
+++ b/src/report/types.rs
@@ -35,6 +35,14 @@ pub struct Hop {
     pub worst: f64,
     #[serde(serialize_with = "fixed_width")]
     pub stddev: f64,
+    #[serde(serialize_with = "fixed_width")]
+    pub jitter: f64,
+    #[serde(serialize_with = "fixed_width")]
+    pub javg: f64,
+    #[serde(serialize_with = "fixed_width")]
+    pub jmax: f64,
+    #[serde(serialize_with = "fixed_width")]
+    pub jinta: f64,
 }
 
 impl<R: Resolver> From<(&backend::trace::Hop, &R)> for Hop {
@@ -53,6 +61,10 @@ impl<R: Resolver> From<(&backend::trace::Hop, &R)> for Hop {
             best: value.best_ms().unwrap_or_default(),
             worst: value.worst_ms().unwrap_or_default(),
             stddev: value.stddev_ms(),
+            jitter: value.jitter_ms().unwrap_or_default(),
+            javg: value.javg_ms().unwrap_or_default(),
+            jmax: value.jmax_ms().unwrap_or_default(),
+            jinta: value.jinta().unwrap_or_default(),
         }
     }
 }


### PR DESCRIPTION
The first of three PRs adding the 4 jitter columns to the backend and TUI + JSON
Fixed clippy warnings to pass PR tests
Optional columns Jttr, Javg, Jmax & Jinta
1. The current jitter i.e. round-trip difference with the last round-trip ('Jttr')
2. The average jitter time for all probes at this hop ('Javg')
3. The best round-trip jitter time for all probes at this hop ('Jmax')
4. The smoothed jitter value for all probes at this hop ('Jint')

Testing by running with the optional jitter columns or specify JSON output.
```
cargo run -- -u --tui-custom-columns="THOLSRAVBWjgxi" freebsd.org
```
JSON output:
```
cargo run -- -u -m json freebsd.org  
```