### PR TITLE
feat: calculate and display jitter (#39)

### DIFF
--- a/src/config/columns.rs
+++ b/src/config/columns.rs
@@ -71,6 +71,14 @@ pub enum TuiColumn {
     StdDev,
     /// The status of a hop.
     Status,
+    /// The current jitter i.e. round-trip difference with the last round-trip.
+    Jitter,
+    /// The average jitter time for all probes at this hop.
+    Javg,
+    /// The worst round-trip jitter time for all probes at this hop.
+    Jmax,
+    /// The smoothed jitter value for all probes at this hop.
+    Jinta,
 }
 
 impl TryFrom<char> for TuiColumn {
@@ -89,6 +97,10 @@ impl TryFrom<char> for TuiColumn {
             'w' => Ok(Self::Worst),
             'd' => Ok(Self::StdDev),
             't' => Ok(Self::Status),
+            'j' => Ok(Self::Jitter),
+            'g' => Ok(Self::Javg),
+            'x' => Ok(Self::Jmax),
+            'i' => Ok(Self::Jinta),
             c => Err(anyhow!(format!("unknown column code: {c}"))),
         }
     }
@@ -108,6 +120,10 @@ impl Display for TuiColumn {
             Self::Worst => write!(f, "w"),
             Self::StdDev => write!(f, "d"),
             Self::Status => write!(f, "t"),
+            Self::Jitter => write!(f, "j"),
+            Self::Javg => write!(f, "g"),
+            Self::Jmax => write!(f, "x"),
+            Self::Jinta => write!(f, "i"),
         }
     }
 }
@@ -134,7 +150,7 @@ mod tests {
     }
 
     ///Negative test for invalid characters
-    #[test_case('x' ; "invalid x")]
+    #[test_case('k' ; "invalid k")]
     #[test_case('z' ; "invalid z")]
     fn test_try_invalid_char_for_tui_column(c: char) {
         // Negative test for an unknown character

--- a/src/frontend/columns.rs
+++ b/src/frontend/columns.rs
@@ -79,6 +79,14 @@ pub enum Column {
     StdDev,
     /// The status of a hop.
     Status,
+    /// The current jitter i.e. round-trip difference with the last round-trip.
+    Jitter,
+    /// The average jitter time for all probes at this hop.
+    Javg,
+    /// The worst round-trip jitter time for all probes at this hop.
+    Jmax,
+    /// The smoothed jitter value for all probes at this hop.
+    Jinta,
 }
 
 impl From<Column> for char {
@@ -95,6 +103,10 @@ impl From<Column> for char {
             Column::Worst => 'w',
             Column::StdDev => 'd',
             Column::Status => 't',
+            Column::Jitter => 'j',
+            Column::Javg => 'g',
+            Column::Jmax => 'x',
+            Column::Jinta => 'i',
         }
     }
 }
@@ -113,6 +125,10 @@ impl From<TuiColumn> for Column {
             TuiColumn::Worst => Self::Worst,
             TuiColumn::StdDev => Self::StdDev,
             TuiColumn::Status => Self::Status,
+            TuiColumn::Jitter => Self::Jitter,
+            TuiColumn::Javg => Self::Javg,
+            TuiColumn::Jmax => Self::Jmax,
+            TuiColumn::Jinta => Self::Jinta,
         }
     }
 }
@@ -131,6 +147,10 @@ impl Display for Column {
             Self::Worst => write!(f, "Wrst"),
             Self::StdDev => write!(f, "StDev"),
             Self::Status => write!(f, "Sts"),
+            Self::Jitter => write!(f, "Jttr"),
+            Self::Javg => write!(f, "Javg"),
+            Self::Jmax => write!(f, "Jmax"),
+            Self::Jinta => write!(f, "Jint"),
         }
     }
 }
@@ -151,6 +171,10 @@ impl Column {
             Self::Worst => ColumnWidth::Fixed(7),
             Self::StdDev => ColumnWidth::Fixed(8),
             Self::Status => ColumnWidth::Fixed(7),
+            Self::Jitter => ColumnWidth::Fixed(7),
+            Self::Javg => ColumnWidth::Fixed(7),
+            Self::Jmax => ColumnWidth::Fixed(7),
+            Self::Jinta => ColumnWidth::Fixed(8),
         }
     }
 }

--- a/src/report/types.rs
+++ b/src/report/types.rs
@@ -35,6 +35,14 @@ pub struct Hop {
     pub worst: f64,
     #[serde(serialize_with = "fixed_width")]
     pub stddev: f64,
+    #[serde(serialize_with = "fixed_width")]
+    pub jitter: f64,
+    #[serde(serialize_with = "fixed_width")]
+    pub javg: f64,
+    #[serde(serialize_with = "fixed_width")]
+    pub jmax: f64,
+    #[serde(serialize_with = "fixed_width")]
+    pub jinta: f64,
 }
 
 impl<R: Resolver> From<(&backend::trace::Hop, &R)> for Hop {
@@ -53,6 +61,10 @@ impl<R: Resolver> From<(&backend::trace::Hop, &R)> for Hop {
             best: value.best_ms().unwrap_or_default(),
             worst: value.worst_ms().unwrap_or_default(),
             stddev: value.stddev_ms(),
+            jitter: value.jitter_ms().unwrap_or_default(),
+            javg: value.javg_ms(),
+            jmax: value.jmax_ms().unwrap_or_default(),
+            jinta: value.jinta(),
         }
     }
 }


### PR DESCRIPTION
Closes #39 (by @trkelly23)

The first of three PRs adding the 4 jitter columns to the backend and TUI + JSON:

Optional columns Jttr, Javg, Jmax & Jinta
1. The current jitter i.e. round-trip difference with the last round-trip ('Jttr')
2. The average jitter time for all probes at this hop ('Javg')
3. The best round-trip jitter time for all probes at this hop ('Jmax')
4. The smoothed jitter value for all probes at this hop ('Jint')

Testing by running with the optional jitter columns or specify JSON output.
```
cargo run -- -u --tui-custom-columns="THOLSRAVBWjgxi" freebsd.org
```
JSON output:
```
cargo run -- -u -m json freebsd.org  
```