### PR TITLE
test: add backend tracer tests

### DIFF
--- a/src/backend/trace.rs
+++ b/src/backend/trace.rs
@@ -410,7 +410,7 @@ impl TraceData {
                 hop.total_time += dur;
                 // Before last is set use it to calc jitter
                 let last_ms = hop.last_ms().unwrap_or_default();
-                let jitter_ms = (last_ms - dur_ms).abs();
+                let jitter_ms = (dur_ms - last_ms).abs();
                 let jitter_dur = Duration::from_secs_f64(jitter_ms / 1000_f64);
                 hop.jitter = hop.last.and(Some(jitter_dur));
                 hop.javg += (jitter_ms - hop.javg) / hop.total_recv as f64;

--- a/src/backend/trace.rs
+++ b/src/backend/trace.rs
@@ -415,7 +415,7 @@ impl TraceData {
                 hop.jitter = hop.last.and(Some(jitter_dur));
                 hop.javg += (jitter_ms - hop.javg) / hop.total_recv as f64;
                 // algorithm is from rfc1889, A.8 or rfc3550
-                hop.jinta += jitter_ms - ((hop.jinta + 8.0) / 16.0);
+                hop.jinta += jitter_ms.max(0.5) - ((hop.jinta + 8.0) / 16.0);
                 hop.jmax = hop
                     .jmax
                     .map_or(Some(jitter_dur), |d| Some(d.max(jitter_dur)));

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -19,8 +19,8 @@ pub use net::channel::TracerChannel;
 pub use net::source::SourceAddr;
 pub use net::SocketImpl;
 pub use probe::{
-    Extension, Extensions, IcmpPacketType, MplsLabelStack, MplsLabelStackMember, ProbeState,
-    UnknownExtension,
+    Extension, Extensions, IcmpPacketType, MplsLabelStack, MplsLabelStackMember, Probe,
+    ProbeComplete, ProbeState, UnknownExtension,
 };
 pub use tracer::{CompletionReason, Tracer, TracerRound};
 pub use types::{

--- a/test_resources/backend/ipv4_3probes_3hops_completed.yaml
+++ b/test_resources/backend/ipv4_3probes_3hops_completed.yaml
@@ -1,0 +1,70 @@
+largest_ttl: 3
+rounds:
+  - probes:
+      - 1 C 333 10.1.0.1 0 12340 80
+      - 2 C 777 10.1.0.2 1 12340 80
+      - 3 C 778 10.1.0.3 2 12340 80
+  - probes:
+      - 1 C 123 10.1.0.1 3 12340 80
+      - 2 C 788 10.1.0.2 4 12340 80
+      - 3 C 789 10.1.0.3 5 12340 80
+  - probes:
+      - 1 C 123 10.1.0.1 6 12340 80
+      - 2 C 780 10.1.0.2 7 12340 80
+      - 3 C 781 10.1.0.3 8 12340 80
+expected:
+  hops:
+    - ttl: 1
+      total_sent: 3
+      total_recv: 3
+      loss_pct: 0
+      best_ms: 123
+      worst_ms: 333
+      avg_ms: 193
+      jitter: 0
+      javg: 181.0
+      jinta: 488.642578125
+      jmax: 333
+      addrs:
+        10.1.0.1: 3
+      samples: [123, 123, 333]
+      last_ms: 123
+      last_sequence: 6
+      last_src: 12340
+      last_dest: 80 
+    - ttl: 2
+      total_sent: 3
+      total_recv: 3
+      loss_pct: 0
+      best_ms: 777
+      worst_ms: 788
+      avg_ms: 781.6666666666665
+      jitter: 8
+      javg: 265.33333333333337
+      jinta: 699.814453125
+      jmax: 777.0
+      addrs:
+        10.1.0.2: 3
+      samples: [780, 788, 777]
+      last_ms: 780
+      last_sequence: 7
+      last_src: 12340
+      last_dest: 80 
+    - ttl: 3
+      total_sent: 3
+      total_recv: 3
+      loss_pct: 0
+      best_ms: 778
+      worst_ms: 789
+      avg_ms: 782.6666666666666
+      jitter: 8
+      javg: 265.66666666666663
+      jinta: 700.693359375
+      jmax: 778.0
+      addrs:
+        10.1.0.3: 3
+      samples: [781, 789, 778]
+      last_ms: 781
+      last_sequence: 8
+      last_src: 12340
+      last_dest: 80 

--- a/test_resources/backend/ipv4_3probes_3hops_mixed_multi.yaml
+++ b/test_resources/backend/ipv4_3probes_3hops_mixed_multi.yaml
@@ -1,0 +1,61 @@
+largest_ttl: 3
+rounds:
+  - probes:
+      - 1 C 10 10.0.0.1 0 12345 80
+      - 2 A 12 10.0.0.2 1 12345 80
+      - 3 C 11 10.0.0.3 2 12345 80
+  - probes:
+      - 1 C 101 10.0.0.1 3 12345 80
+      - 2 A 121 10.0.0.2 4 12345 80
+      - 3 C 111 10.0.0.4 5 12345 80
+expected:
+  hops:
+    - ttl: 1
+      total_sent: 2
+      total_recv: 2
+      loss_pct: 0
+      best_ms: 10
+      worst_ms: 101
+      avg_ms: 55.5
+      jitter: 91
+      javg: 50.5
+      jinta: 99.40625
+      jmax: 91
+      addrs:
+        10.0.0.1: 2
+      samples: [101, 10]
+      last_ms: 101
+      last_src: 12345
+      last_dest: 80
+      last_sequence: 3
+    - ttl: 2
+      total_sent: 2
+      total_recv: 0
+      loss_pct: 100
+      avg_ms: 0
+      javg: 0
+      jinta: 0
+      addrs:
+      samples: [0, 0]
+      last_src: 12345
+      last_dest: 80
+      last_sequence: 4
+    - ttl: 3
+      total_sent: 2
+      total_recv: 2
+      loss_pct: 0
+      best_ms: 11
+      worst_ms: 111
+      avg_ms: 61
+      jitter: 100
+      javg:  55.5
+      jinta: 109.34375
+      jmax: 100
+      addrs:
+        10.0.0.3: 1
+        10.0.0.4: 1
+      samples: [111, 11]
+      last_ms: 111
+      last_src: 12345
+      last_dest: 80
+      last_sequence: 5

--- a/test_resources/backend/ipv4_4probes_0latency.yaml
+++ b/test_resources/backend/ipv4_4probes_0latency.yaml
@@ -1,0 +1,30 @@
+largest_ttl: 1
+rounds:
+  - probes:
+      - 1 C 0 127.0.0.1 0 80 80
+  - probes:
+      - 1 C 0 127.0.0.1 0 80 80
+  - probes:
+      - 1 C 0 127.0.0.1 0 80 80
+  - probes:
+      - 1 C 0 127.0.0.1 0 80 80
+expected:
+  hops:
+    - ttl: 1
+      total_sent: 4
+      total_recv: 4
+      loss_pct: 0
+      last_ms: 0.0
+      best_ms: 0
+      worst_ms: 0
+      avg_ms: 0
+      addrs:
+        127.0.0.1: 1
+      samples: [0, 0, 0, 0]
+      jitter: 0
+      javg: 0.0
+      jmax: 0.0
+      jinta: 0.0
+      last_sequence: 0
+      last_src: 80
+      last_dest: 80

--- a/test_resources/backend/ipv4_4probes_all_status.yaml
+++ b/test_resources/backend/ipv4_4probes_all_status.yaml
@@ -1,0 +1,30 @@
+largest_ttl: 1
+rounds:
+  - probes:
+      - 1 A 300 10.1.0.2 0 12340 80
+  - probes:
+      - 1 C 700 10.1.0.2 0 12340 80
+  - probes:
+      - 1 N 300 10.1.0.2 0 12340 80
+  - probes:
+      - 1 S 300 10.1.0.2 0 12340 80
+expected:
+  hops:
+    - ttl: 1
+      total_sent: 2
+      total_recv: 1
+      loss_pct: 50
+      best_ms: 700
+      worst_ms: 700
+      avg_ms: 700
+      # jitter: None
+      javg: 700
+      jmax: 700
+      jinta: 699.5
+      addrs:
+        10.1.0.2: 1
+      samples: [700.0, 0.0]
+      last_ms: 700
+      last_sequence: 0
+      last_src: 12340
+      last_dest: 80 


### PR DESCRIPTION
The PR includes tests for a single hop and 0 to n probes for various probe statuses.  
Note: I did not add mean & m2 to the equality test but plan to add them later.
During tests, it was found that low latency of .5 millis the Jinta value turned negative.  According to the RFC near zero should remain 0 because is minimal.  Added check jinta.max(0.5)

A couple of items to please review:
1) I made tracer & type(src/tracing.rs) public to integrate with tests.  Not completely kosher as some libs are private and public.
2)  I'm looking for a suggestion to add multiple hops to tests.  Can you please suggest it?
3) Are there other missing test cases besides multiple hops?
4) The location of the YAML files is under the backend folder.  I ran into multiple issues moving outside the src directory.  Stumped on it.
