### PR TITLE
fix(net): tracer panic for ICMP TimeExceeded packets with code 1 (#979)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +596,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures-channel"
@@ -1031,6 +1043,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,6 +1199,32 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -1583,6 +1648,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "test-case"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,6 +1948,7 @@ dependencies = [
  "ipnetwork",
  "itertools",
  "maxminddb",
+ "mockall",
  "nix",
  "parking_lot",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ serde_yaml = "0.9.31"
 tokio = { version = "1.35.1", features = [ "full" ] }
 tokio-util = "0.7.10"
 ipnetwork = "0.20.0"
+mockall = "0.12.1"
 
 # see https://github.com/meh/rust-tun/pull/74
 [target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))'.dev-dependencies]

--- a/src/tracing/net/ipv4.rs
+++ b/src/tracing/net/ipv4.rs
@@ -9,7 +9,7 @@ use crate::tracing::packet::icmpv4::destination_unreachable::DestinationUnreacha
 use crate::tracing::packet::icmpv4::echo_reply::EchoReplyPacket;
 use crate::tracing::packet::icmpv4::echo_request::EchoRequestPacket;
 use crate::tracing::packet::icmpv4::time_exceeded::TimeExceededPacket;
-use crate::tracing::packet::icmpv4::{IcmpCode, IcmpPacket, IcmpType};
+use crate::tracing::packet::icmpv4::{IcmpCode, IcmpPacket, IcmpTimeExceededCode, IcmpType};
 use crate::tracing::packet::ipv4::Ipv4Packet;
 use crate::tracing::packet::tcp::TcpPacket;
 use crate::tracing::packet::udp::UdpPacket;
@@ -352,23 +352,32 @@ fn extract_probe_resp(
     let recv = SystemTime::now();
     let src = IpAddr::V4(ipv4.get_source());
     let icmp_v4 = IcmpPacket::new_view(ipv4.payload())?;
-    Ok(match icmp_v4.get_icmp_type() {
+    let icmp_type = icmp_v4.get_icmp_type();
+    let icmp_code = icmp_v4.get_icmp_code();
+    Ok(match icmp_type {
         IcmpType::TimeExceeded => {
-            let packet = TimeExceededPacket::new_view(icmp_v4.packet())?;
-            let (nested_ipv4, extension) = match icmp_extension_mode {
-                IcmpExtensionParseMode::Enabled => {
-                    let ipv4 = Ipv4Packet::new_view(packet.payload())?;
-                    let ext = packet.extension().map(Extensions::try_from).transpose()?;
-                    (ipv4, ext)
-                }
-                IcmpExtensionParseMode::Disabled => {
-                    let ipv4 = Ipv4Packet::new_view(packet.payload_raw())?;
-                    (ipv4, None)
-                }
-            };
-            extract_probe_resp_seq(&nested_ipv4, protocol)?.map(|resp_seq| {
-                ProbeResponse::TimeExceeded(ProbeResponseData::new(recv, src, resp_seq), extension)
-            })
+            if IcmpTimeExceededCode::from(icmp_code) == IcmpTimeExceededCode::TtlExpired {
+                let packet = TimeExceededPacket::new_view(icmp_v4.packet())?;
+                let (nested_ipv4, extension) = match icmp_extension_mode {
+                    IcmpExtensionParseMode::Enabled => {
+                        let ipv4 = Ipv4Packet::new_view(packet.payload())?;
+                        let ext = packet.extension().map(Extensions::try_from).transpose()?;
+                        (ipv4, ext)
+                    }
+                    IcmpExtensionParseMode::Disabled => {
+                        let ipv4 = Ipv4Packet::new_view(packet.payload_raw())?;
+                        (ipv4, None)
+                    }
+                };
+                extract_probe_resp_seq(&nested_ipv4, protocol)?.map(|resp_seq| {
+                    ProbeResponse::TimeExceeded(
+                        ProbeResponseData::new(recv, src, resp_seq),
+                        extension,
+                    )
+                })
+            } else {
+                None
+            }
         }
         IcmpType::DestinationUnreachable => {
             let packet = DestinationUnreachablePacket::new_view(icmp_v4.packet())?;
@@ -471,5 +480,37 @@ fn extract_tcp_packet(ipv4: &Ipv4Packet<'_>) -> TraceResult<(u16, u16)> {
     } else {
         let tcp_packet = TcpPacket::new_view(nested_tcp)?;
         Ok((tcp_packet.get_source(), tcp_packet.get_destination()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tracing::error::IoResult;
+    use crate::tracing::net::socket::MockSocket;
+    use crate::mocket_read;
+
+    // This IPv4/ICMP TimeExceeded packet has code 1 ("Fragment reassembly
+    // time exceeded") and must be ignored.
+    //
+    // Note this is not real packet and so the length and checksum are not
+    // accurate.
+    #[test]
+    fn test_icmp_time_exceeded_fragment_reassembly_ignored() -> anyhow::Result<()> {
+        let expected_read_buf = hex_literal::hex!(
+            "
+           45 20 2c 02 e4 5c 00 00 72 01 2e 04 67 4b 0b 34
+           c0 a8 01 15 0b 01 1c 38 00 00 00 00 45 00 8c 05
+           85 4e 20 00 30 11 ab d6 c0 a8 01 15 67 4b 0b 34
+           "
+        );
+        let mut mocket = MockSocket::new();
+        mocket
+            .expect_read()
+            .times(1)
+            .returning(mocket_read!(expected_read_buf));
+        let resp = recv_icmp_probe(&mut mocket, Protocol::Udp, IcmpExtensionParseMode::Enabled)?;
+        assert!(resp.is_none());
+        Ok(())
     }
 }

--- a/src/tracing/net/socket.rs
+++ b/src/tracing/net/socket.rs
@@ -2,6 +2,7 @@ use crate::tracing::error::IoResult as Result;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::Duration;
 
+#[cfg_attr(test, mockall::automock)]
 pub trait Socket
 where
     Self: Sized,
@@ -45,4 +46,27 @@ where
     fn take_error(&mut self) -> Result<Option<std::io::Error>>;
     fn icmp_error_info(&mut self) -> Result<IpAddr>;
     fn close(&mut self) -> Result<()>;
+}
+
+#[cfg(test)]
+pub mod tests {
+    #[macro_export]
+    macro_rules! mocket_read {
+        ($packet: expr) => {
+            move |buf: &mut [u8]| -> IoResult<usize> {
+                buf[..$packet.len()].copy_from_slice(&$packet);
+                Ok(buf.len())
+            }
+        };
+    }
+
+    #[macro_export]
+    macro_rules! mocket_recv_from {
+        ($packet: expr, $addr: expr) => {
+            move |buf: &mut [u8]| -> IoResult<(usize, Option<SocketAddr>)> {
+                buf[..$packet.len()].copy_from_slice(&$packet);
+                Ok((buf.len(), Some($addr)))
+            }
+        };
+    }
 }

--- a/src/tracing/packet/icmpv4.rs
+++ b/src/tracing/packet/icmpv4.rs
@@ -47,6 +47,27 @@ impl From<u8> for IcmpCode {
     }
 }
 
+/// The code for `TimeExceeded` ICMP packet type.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub enum IcmpTimeExceededCode {
+    /// TTL expired in transit.
+    TtlExpired,
+    /// Fragment reassembly time exceeded.
+    FragmentReassembly,
+    /// An unknown code.
+    Unknown(u8),
+}
+
+impl From<IcmpCode> for IcmpTimeExceededCode {
+    fn from(val: IcmpCode) -> Self {
+        match val {
+            IcmpCode(0) => Self::TtlExpired,
+            IcmpCode(1) => Self::FragmentReassembly,
+            IcmpCode(id) => Self::Unknown(id),
+        }
+    }
+}
+
 const TYPE_OFFSET: usize = 0;
 const CODE_OFFSET: usize = 1;
 const CHECKSUM_OFFSET: usize = 2;

--- a/src/tracing/packet/icmpv6.rs
+++ b/src/tracing/packet/icmpv6.rs
@@ -47,6 +47,27 @@ impl From<u8> for IcmpCode {
     }
 }
 
+/// The code for `TimeExceeded` `ICMPv6` packet type.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub enum IcmpTimeExceededCode {
+    /// Hop limit exceeded in transit.
+    TtlExpired,
+    /// Fragment reassembly time exceeded.
+    FragmentReassembly,
+    /// An unknown code.
+    Unknown(u8),
+}
+
+impl From<IcmpCode> for IcmpTimeExceededCode {
+    fn from(val: IcmpCode) -> Self {
+        match val {
+            IcmpCode(0) => Self::TtlExpired,
+            IcmpCode(1) => Self::FragmentReassembly,
+            IcmpCode(id) => Self::Unknown(id),
+        }
+    }
+}
+
 const TYPE_OFFSET: usize = 0;
 const CODE_OFFSET: usize = 1;
 const CHECKSUM_OFFSET: usize = 2;


### PR DESCRIPTION
Closes #979 