### PR TITLE
fix(net): create non-raw ipv4 socket with `new_udp_send_socket_ipv4(false)`

### DIFF
--- a/src/tracing/net/ipv4.rs
+++ b/src/tracing/net/ipv4.rs
@@ -181,7 +181,7 @@ fn dispatch_udp_probe_non_raw<S: Socket>(
 ) -> TraceResult<()> {
     let local_addr = SocketAddr::new(IpAddr::V4(src_addr), probe.src_port.0);
     let remote_addr = SocketAddr::new(IpAddr::V4(dest_addr), probe.dest_port.0);
-    let mut socket = S::new_udp_dgram_socket_ipv4()?;
+    let mut socket = S::new_udp_send_socket_ipv4(false)?;
     process_result(local_addr, socket.bind(local_addr))?;
     socket.set_ttl(u32::from(probe.ttl.0))?;
     socket.send_to(payload, remote_addr)?;
@@ -774,8 +774,8 @@ mod tests {
 
         let mut mocket = MockSocket::new();
 
-        let ctx = MockSocket::new_udp_dgram_socket_ipv4_context();
-        ctx.expect().returning(move || {
+        let ctx = MockSocket::new_udp_send_socket_ipv4_context();
+        ctx.expect().with(predicate::eq(false)).returning(move |_| {
             let mut mocket = MockSocket::new();
             mocket
                 .expect_bind()
@@ -831,8 +831,8 @@ mod tests {
 
         let mut mocket = MockSocket::new();
 
-        let ctx = MockSocket::new_udp_dgram_socket_ipv4_context();
-        ctx.expect().returning(move || {
+        let ctx = MockSocket::new_udp_send_socket_ipv4_context();
+        ctx.expect().with(predicate::eq(false)).returning(move |_| {
             let mut mocket = MockSocket::new();
             mocket
                 .expect_bind()

--- a/tests/resources/simulation/ipv4_udp_classic_unprivileged.yaml
+++ b/tests/resources/simulation/ipv4_udp_classic_unprivileged.yaml
@@ -1,0 +1,19 @@
+name: IPv4/UDP classic unprivileged
+privilege_mode: Unprivileged
+target: 10.0.0.103
+protocol: Udp
+port_direction: !FixedDest 33000
+multipath_strategy: Classic
+hops:
+  - ttl: 1
+    resp: !SingleHost
+      addr: 10.0.0.101
+      rtt_ms: 10
+  - ttl: 2
+    resp: !SingleHost
+      addr: 10.0.0.102
+      rtt_ms: 20
+  - ttl: 3
+    resp: !SingleHost
+      addr: 10.0.0.103
+      rtt_ms: 20

--- a/tests/sim/simulation.rs
+++ b/tests/sim/simulation.rs
@@ -6,6 +6,8 @@ use trippy::tracing::Port;
 #[derive(Debug, Deserialize)]
 pub struct Simulation {
     pub name: String,
+    #[serde(default)]
+    pub privilege_mode: PrivilegeMode,
     pub target: IpAddr,
     pub protocol: Protocol,
     #[serde(default)]
@@ -57,6 +59,22 @@ pub struct SingleHost {
     pub addr: IpAddr,
     /// The simulated round trim time (RTT) in ms.
     pub rtt_ms: u16,
+}
+
+#[derive(Copy, Clone, Debug, Default, Deserialize)]
+pub enum PrivilegeMode {
+    #[default]
+    Privileged,
+    Unprivileged,
+}
+
+impl From<PrivilegeMode> for trippy::tracing::PrivilegeMode {
+    fn from(value: PrivilegeMode) -> Self {
+        match value {
+            PrivilegeMode::Privileged => Self::Privileged,
+            PrivilegeMode::Unprivileged => Self::Unprivileged,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Deserialize)]

--- a/tests/sim/tests.rs
+++ b/tests/sim/tests.rs
@@ -49,6 +49,13 @@ fn test_simulation(simulation: Simulation) -> anyhow::Result<()> {
     run_simulation_with_retry(simulation)
 }
 
+// unprivileged mode is only supported on macOS
+#[cfg(target_os = "macos")]
+#[test_case(sim!("ipv4_udp_classic_unprivileged.yaml"))]
+fn test_simulation_macos(simulation: Simulation) -> anyhow::Result<()> {
+    run_simulation_with_retry(simulation)
+}
+
 fn run_simulation_with_retry(simulation: Simulation) -> anyhow::Result<()> {
     let runtime = runtime().lock().unwrap();
     let simulation = Arc::new(simulation);

--- a/tests/sim/tracer.rs
+++ b/tests/sim/tracer.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 use trippy::tracing::{
     defaults, Builder, CompletionReason, MaxRounds, MultipathStrategy, PacketSize, PayloadPattern,
-    PortDirection, ProbeState, Protocol, TimeToLive, TraceId, TracerRound,
+    PortDirection, PrivilegeMode, ProbeState, Protocol, TimeToLive, TraceId, TracerRound,
 };
 
 // The length of time to wait after the completion of the tracing before
@@ -51,6 +51,7 @@ impl Tracer {
     pub fn trace(&self) -> anyhow::Result<()> {
         let result = RefCell::new(Ok(()));
         let tracer_res = Builder::new(self.sim.target, |round| self.validate_round(round, &result))
+            .privilege_mode(PrivilegeMode::from(self.sim.privilege_mode))
             .trace_identifier(TraceId(self.sim.icmp_identifier))
             .protocol(Protocol::from(self.sim.protocol))
             .port_direction(PortDirection::from(self.sim.port_direction))


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Updated UDP socket creation to use `new_udp_send_socket_ipv4(false)` for non-blocking mode, replacing the previous `new_udp_dgram_socket_ipv4` method.
- Modified unit tests to align with the new method of UDP socket creation, ensuring the correct behavior of non-blocking sockets.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ipv4.rs</strong><dd><code>Update UDP Socket Creation to Non-Blocking Mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tracing/net/ipv4.rs
<li>Updated the method to create a UDP socket from <br><code>new_udp_dgram_socket_ipv4</code> to <code>new_udp_send_socket_ipv4</code> with a <code>false</code> <br>parameter indicating non-blocking mode.<br> <li> Adjusted unit tests to expect the <code>new_udp_send_socket_ipv4</code> method with <br><code>false</code> as an argument instead of the previous <code>new_udp_dgram_socket_ipv4</code> <br>method.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1040/files#diff-66962cba4986141ee44d753d463b743338c6b87425965b3be0338863e0312951">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

