### PR TITLE
add more unit tests

### DIFF
--- a/src/tracing/packet/buffer.rs
+++ b/src/tracing/packet/buffer.rs
@@ -50,3 +50,64 @@ impl<'a> Buffer<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_immutable_buffer() {
+        let buf = [0_u8; 5];
+        let buffer = Buffer::Immutable(&buf);
+        assert_eq!(buf.as_slice(), buffer.as_slice());
+        assert_eq!(buf, buffer.get_bytes(0));
+        assert_eq!(0_u8, buffer.read(0));
+    }
+
+    #[test]
+    fn test_mutable_buffer() {
+        let mut buf = [0_u8; 5];
+        let mut buffer = Buffer::Mutable(&mut buf);
+        assert_eq!(&[0_u8; 5], buffer.as_slice());
+        assert_eq!([0_u8; 5], buffer.get_bytes(0));
+        assert_eq!(0_u8, buffer.read(0));
+        buffer.set_bytes(1, [1_u8; 4]);
+        assert_eq!([1_u8; 4], buffer.get_bytes(1));
+        *buffer.write(0) = 2;
+        assert_eq!(2_u8, buffer.read(0));
+        buffer.as_slice_mut().copy_from_slice(&[3_u8; 5]);
+        assert_eq!(&[3_u8; 5], buffer.as_slice());
+    }
+
+    #[test]
+    fn test_debug() {
+        let buf = [0_u8; 5];
+        let buffer = Buffer::Immutable(&buf);
+        assert_eq!(
+            String::from("Immutable([0, 0, 0, 0, 0])"),
+            format!("{buffer:?}")
+        );
+        let mut buf = [0_u8; 5];
+        let buffer = Buffer::Mutable(&mut buf);
+        assert_eq!(
+            String::from("Mutable([0, 0, 0, 0, 0])"),
+            format!("{buffer:?}")
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "write operation called on readonly buffer")]
+    fn test_immutable_buffer_cannot_write() {
+        let buf = [0_u8; 5];
+        let mut buffer = Buffer::Immutable(&buf);
+        buffer.set_bytes(0, [1_u8; 5]);
+    }
+
+    #[test]
+    #[should_panic(expected = "write operation called on readonly buffer")]
+    fn test_immutable_buffer_cannot_mut_slice() {
+        let buf = [0_u8; 5];
+        let mut buffer = Buffer::Immutable(&buf);
+        buffer.as_slice_mut();
+    }
+}

--- a/src/tracing/packet/checksum.rs
+++ b/src/tracing/packet/checksum.rs
@@ -129,6 +129,29 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
+    fn test_empty_ipv4_checksum() {
+        let src_addr = Ipv4Addr::from_str("192.168.1.201").unwrap();
+        let dest_addr = Ipv4Addr::from_str("142.250.66.46").unwrap();
+        assert_eq!(0, ipv4_header_checksum(&[]));
+        assert_eq!(0, icmp_ipv4_checksum(&[]));
+        assert_eq!(27732, udp_ipv4_checksum(&[], src_addr, dest_addr));
+        assert_eq!(27743, tcp_ipv4_checksum(&[], src_addr, dest_addr));
+    }
+
+    #[test]
+    fn test_empty_ipv6_checksum() {
+        let src_addr = Ipv6Addr::from_str("fe80::811:3f6:7601:6c3f").unwrap();
+        let dest_addr = Ipv6Addr::from_str("fe80::1c8d:7d69:d0b6:8182").unwrap();
+        assert_eq!(10316, icmp_ipv6_checksum(&[], src_addr, dest_addr));
+        assert_eq!(10357, udp_ipv6_checksum(&[], src_addr, dest_addr));
+    }
+
+    #[test]
+    fn test_odd_length() {
+        assert_eq!(65535, ipv4_header_checksum(&[0x00]));
+    }
+
+    #[test]
     fn test_icmp_ipv4_checksum() {
         let bytes = [
             0x0b, 0x00, 0x88, 0xeb, 0x00, 0x00, 0x00, 0x00, 0x45, 0x00, 0x00, 0x54, 0xb0, 0xde,

--- a/src/tracing/packet/error.rs
+++ b/src/tracing/packet/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 pub type PacketResult<T> = Result<T, PacketError>;
 
 /// A packet error.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Eq, PartialEq)]
 pub enum PacketError {
     /// Attempting to create a packet with a insufficient buffer size.
     #[error("insufficient buffer for {0} packet, minimum={1}, provided={2}")]

--- a/src/tracing/packet/icmpv4.rs
+++ b/src/tracing/packet/icmpv4.rs
@@ -211,6 +211,28 @@ mod tests {
         assert_eq!(u16::MAX, packet.get_checksum());
         assert_eq!([0xFF, 0xFF], packet.packet()[2..=3]);
     }
+
+    #[test]
+    fn test_new_insufficient_buffer() {
+        const SIZE: usize = IcmpPacket::minimum_packet_size();
+        let mut buf = [0_u8; SIZE - 1];
+        let err = IcmpPacket::new(&mut buf).unwrap_err();
+        assert_eq!(
+            PacketError::InsufficientPacketBuffer(String::from("IcmpPacket"), SIZE, SIZE - 1),
+            err
+        );
+    }
+
+    #[test]
+    fn test_new_view_insufficient_buffer() {
+        const SIZE: usize = IcmpPacket::minimum_packet_size();
+        let buf = [0_u8; SIZE - 1];
+        let err = IcmpPacket::new_view(&buf).unwrap_err();
+        assert_eq!(
+            PacketError::InsufficientPacketBuffer(String::from("IcmpPacket"), SIZE, SIZE - 1),
+            err
+        );
+    }
 }
 
 pub mod echo_request {
@@ -439,6 +461,36 @@ pub mod echo_request {
             assert_eq!(24731, packet.get_identifier());
             assert_eq!(33000, packet.get_sequence());
             assert!(packet.payload().is_empty());
+        }
+
+        #[test]
+        fn test_new_insufficient_buffer() {
+            const SIZE: usize = EchoRequestPacket::minimum_packet_size();
+            let mut buf = [0_u8; SIZE - 1];
+            let err = EchoRequestPacket::new(&mut buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("EchoRequestPacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
+        }
+
+        #[test]
+        fn test_new_view_insufficient_buffer() {
+            const SIZE: usize = EchoRequestPacket::minimum_packet_size();
+            let buf = [0_u8; SIZE - 1];
+            let err = EchoRequestPacket::new_view(&buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("EchoRequestPacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
         }
     }
 }
@@ -670,6 +722,36 @@ pub mod echo_reply {
             assert_eq!(33012, packet.get_sequence());
             assert!(packet.payload().is_empty());
         }
+
+        #[test]
+        fn test_new_insufficient_buffer() {
+            const SIZE: usize = EchoReplyPacket::minimum_packet_size();
+            let mut buf = [0_u8; SIZE - 1];
+            let err = EchoReplyPacket::new(&mut buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("EchoReplyPacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
+        }
+
+        #[test]
+        fn test_new_view_insufficient_buffer() {
+            const SIZE: usize = EchoReplyPacket::minimum_packet_size();
+            let buf = [0_u8; SIZE - 1];
+            let err = EchoReplyPacket::new_view(&buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("EchoReplyPacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
+        }
     }
 }
 
@@ -894,6 +976,36 @@ pub mod time_exceeded {
             assert_eq!(62702, packet.get_checksum());
             assert_eq!(17, packet.get_length());
             assert!(packet.payload().is_empty());
+        }
+
+        #[test]
+        fn test_new_insufficient_buffer() {
+            const SIZE: usize = TimeExceededPacket::minimum_packet_size();
+            let mut buf = [0_u8; SIZE - 1];
+            let err = TimeExceededPacket::new(&mut buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("TimeExceededPacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
+        }
+
+        #[test]
+        fn test_new_view_insufficient_buffer() {
+            const SIZE: usize = TimeExceededPacket::minimum_packet_size();
+            let buf = [0_u8; SIZE - 1];
+            let err = TimeExceededPacket::new_view(&buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("TimeExceededPacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
         }
     }
 }
@@ -1127,6 +1239,36 @@ pub mod destination_unreachable {
             assert_eq!(57308, packet.get_checksum());
             assert_eq!(0, packet.get_length());
             assert!(packet.payload().is_empty());
+        }
+
+        #[test]
+        fn test_new_insufficient_buffer() {
+            const SIZE: usize = DestinationUnreachablePacket::minimum_packet_size();
+            let mut buf = [0_u8; SIZE - 1];
+            let err = DestinationUnreachablePacket::new(&mut buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("DestinationUnreachablePacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
+        }
+
+        #[test]
+        fn test_new_view_insufficient_buffer() {
+            const SIZE: usize = DestinationUnreachablePacket::minimum_packet_size();
+            let buf = [0_u8; SIZE - 1];
+            let err = DestinationUnreachablePacket::new_view(&buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("DestinationUnreachablePacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
         }
     }
 }

--- a/src/tracing/packet/icmpv6.rs
+++ b/src/tracing/packet/icmpv6.rs
@@ -211,6 +211,28 @@ mod tests {
         assert_eq!(u16::MAX, packet.get_checksum());
         assert_eq!([0xFF, 0xFF], packet.packet()[2..=3]);
     }
+
+    #[test]
+    fn test_new_insufficient_buffer() {
+        const SIZE: usize = IcmpPacket::minimum_packet_size();
+        let mut buf = [0_u8; SIZE - 1];
+        let err = IcmpPacket::new(&mut buf).unwrap_err();
+        assert_eq!(
+            PacketError::InsufficientPacketBuffer(String::from("IcmpPacket"), SIZE, SIZE - 1),
+            err
+        );
+    }
+
+    #[test]
+    fn test_new_view_insufficient_buffer() {
+        const SIZE: usize = IcmpPacket::minimum_packet_size();
+        let buf = [0_u8; SIZE - 1];
+        let err = IcmpPacket::new_view(&buf).unwrap_err();
+        assert_eq!(
+            PacketError::InsufficientPacketBuffer(String::from("IcmpPacket"), SIZE, SIZE - 1),
+            err
+        );
+    }
 }
 
 pub mod echo_request {
@@ -439,6 +461,36 @@ pub mod echo_request {
             assert_eq!(24731, packet.get_identifier());
             assert_eq!(33000, packet.get_sequence());
             assert!(packet.payload().is_empty());
+        }
+
+        #[test]
+        fn test_new_insufficient_buffer() {
+            const SIZE: usize = EchoRequestPacket::minimum_packet_size();
+            let mut buf = [0_u8; SIZE - 1];
+            let err = EchoRequestPacket::new(&mut buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("EchoRequestPacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
+        }
+
+        #[test]
+        fn test_new_view_insufficient_buffer() {
+            const SIZE: usize = EchoRequestPacket::minimum_packet_size();
+            let buf = [0_u8; SIZE - 1];
+            let err = EchoRequestPacket::new_view(&buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("EchoRequestPacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
         }
     }
 }
@@ -670,6 +722,36 @@ pub mod echo_reply {
             assert_eq!(33012, packet.get_sequence());
             assert!(packet.payload().is_empty());
         }
+
+        #[test]
+        fn test_new_insufficient_buffer() {
+            const SIZE: usize = EchoReplyPacket::minimum_packet_size();
+            let mut buf = [0_u8; SIZE - 1];
+            let err = EchoReplyPacket::new(&mut buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("EchoReplyPacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
+        }
+
+        #[test]
+        fn test_new_view_insufficient_buffer() {
+            const SIZE: usize = EchoReplyPacket::minimum_packet_size();
+            let buf = [0_u8; SIZE - 1];
+            let err = EchoReplyPacket::new_view(&buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("EchoReplyPacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
+        }
     }
 }
 
@@ -891,6 +973,36 @@ pub mod time_exceeded {
             assert_eq!(62702, packet.get_checksum());
             assert_eq!(17, packet.get_length());
             assert!(packet.payload().is_empty());
+        }
+
+        #[test]
+        fn test_new_insufficient_buffer() {
+            const SIZE: usize = TimeExceededPacket::minimum_packet_size();
+            let mut buf = [0_u8; SIZE - 1];
+            let err = TimeExceededPacket::new(&mut buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("TimeExceededPacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
+        }
+
+        #[test]
+        fn test_new_view_insufficient_buffer() {
+            const SIZE: usize = TimeExceededPacket::minimum_packet_size();
+            let buf = [0_u8; SIZE - 1];
+            let err = TimeExceededPacket::new_view(&buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("TimeExceededPacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
         }
     }
 }
@@ -1127,6 +1239,36 @@ pub mod destination_unreachable {
             assert_eq!(57308, packet.get_checksum());
             assert_eq!(0, packet.get_length());
             assert!(packet.payload().is_empty());
+        }
+
+        #[test]
+        fn test_new_insufficient_buffer() {
+            const SIZE: usize = DestinationUnreachablePacket::minimum_packet_size();
+            let mut buf = [0_u8; SIZE - 1];
+            let err = DestinationUnreachablePacket::new(&mut buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("DestinationUnreachablePacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
+        }
+
+        #[test]
+        fn test_new_view_insufficient_buffer() {
+            const SIZE: usize = DestinationUnreachablePacket::minimum_packet_size();
+            let buf = [0_u8; SIZE - 1];
+            let err = DestinationUnreachablePacket::new_view(&buf).unwrap_err();
+            assert_eq!(
+                PacketError::InsufficientPacketBuffer(
+                    String::from("DestinationUnreachablePacket"),
+                    SIZE,
+                    SIZE - 1
+                ),
+                err
+            );
         }
     }
 }

--- a/src/tracing/packet/ipv4.rs
+++ b/src/tracing/packet/ipv4.rs
@@ -458,4 +458,26 @@ mod tests {
         );
         assert!(packet.payload().is_empty());
     }
+
+    #[test]
+    fn test_new_insufficient_buffer() {
+        const SIZE: usize = Ipv4Packet::minimum_packet_size();
+        let mut buf = [0_u8; SIZE - 1];
+        let err = Ipv4Packet::new(&mut buf).unwrap_err();
+        assert_eq!(
+            PacketError::InsufficientPacketBuffer(String::from("Ipv4Packet"), SIZE, SIZE - 1),
+            err
+        );
+    }
+
+    #[test]
+    fn test_new_view_insufficient_buffer() {
+        const SIZE: usize = Ipv4Packet::minimum_packet_size();
+        let buf = [0_u8; SIZE - 1];
+        let err = Ipv4Packet::new_view(&buf).unwrap_err();
+        assert_eq!(
+            PacketError::InsufficientPacketBuffer(String::from("Ipv4Packet"), SIZE, SIZE - 1),
+            err
+        );
+    }
 }

--- a/src/tracing/packet/ipv6.rs
+++ b/src/tracing/packet/ipv6.rs
@@ -370,4 +370,26 @@ mod tests {
         );
         assert!(packet.payload().is_empty());
     }
+
+    #[test]
+    fn test_new_insufficient_buffer() {
+        const SIZE: usize = Ipv6Packet::minimum_packet_size();
+        let mut buf = [0_u8; SIZE - 1];
+        let err = Ipv6Packet::new(&mut buf).unwrap_err();
+        assert_eq!(
+            PacketError::InsufficientPacketBuffer(String::from("Ipv6Packet"), SIZE, SIZE - 1),
+            err
+        );
+    }
+
+    #[test]
+    fn test_new_view_insufficient_buffer() {
+        const SIZE: usize = Ipv6Packet::minimum_packet_size();
+        let buf = [0_u8; SIZE - 1];
+        let err = Ipv6Packet::new_view(&buf).unwrap_err();
+        assert_eq!(
+            PacketError::InsufficientPacketBuffer(String::from("Ipv6Packet"), SIZE, SIZE - 1),
+            err
+        );
+    }
 }

--- a/src/tracing/packet/tcp.rs
+++ b/src/tracing/packet/tcp.rs
@@ -443,4 +443,26 @@ mod tests {
         );
         assert!(packet.payload().is_empty());
     }
+
+    #[test]
+    fn test_new_insufficient_buffer() {
+        const SIZE: usize = TcpPacket::minimum_packet_size();
+        let mut buf = [0_u8; SIZE - 1];
+        let err = TcpPacket::new(&mut buf).unwrap_err();
+        assert_eq!(
+            PacketError::InsufficientPacketBuffer(String::from("TcpPacket"), SIZE, SIZE - 1),
+            err
+        );
+    }
+
+    #[test]
+    fn test_new_view_insufficient_buffer() {
+        const SIZE: usize = TcpPacket::minimum_packet_size();
+        let buf = [0_u8; SIZE - 1];
+        let err = TcpPacket::new_view(&buf).unwrap_err();
+        assert_eq!(
+            PacketError::InsufficientPacketBuffer(String::from("TcpPacket"), SIZE, SIZE - 1),
+            err
+        );
+    }
 }

--- a/src/tracing/packet/udp.rs
+++ b/src/tracing/packet/udp.rs
@@ -201,4 +201,26 @@ mod tests {
         assert_eq!(44222, packet.get_checksum());
         assert!(packet.payload().is_empty());
     }
+
+    #[test]
+    fn test_new_insufficient_buffer() {
+        const SIZE: usize = UdpPacket::minimum_packet_size();
+        let mut buf = [0_u8; SIZE - 1];
+        let err = UdpPacket::new(&mut buf).unwrap_err();
+        assert_eq!(
+            PacketError::InsufficientPacketBuffer(String::from("UdpPacket"), SIZE, SIZE - 1),
+            err
+        );
+    }
+
+    #[test]
+    fn test_new_view_insufficient_buffer() {
+        const SIZE: usize = UdpPacket::minimum_packet_size();
+        let buf = [0_u8; SIZE - 1];
+        let err = UdpPacket::new_view(&buf).unwrap_err();
+        assert_eq!(
+            PacketError::InsufficientPacketBuffer(String::from("UdpPacket"), SIZE, SIZE - 1),
+            err
+        );
+    }
 }


### PR DESCRIPTION
## **Type**
Tests, Enhancement


___

## **Description**
- Added a variety of unit tests across different modules, focusing on buffer functionalities, checksum calculations, and error handling.
- Introduced tests for handling insufficient buffer sizes for packet creation across multiple protocols (ICMPv4, ICMPv6, IPv4, IPv6, TCP, UDP).
- Enhanced `PacketError` with `Eq` and `PartialEq` traits to facilitate better testing.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>extension.rs</strong><dd><code>Added Unit Tests for ICMP Extensions Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tracing/net/extension.rs
<li>Added unit tests for converting MPLS and unknown extensions.<br> <li> Added a test for handling an extension with an unknown header version.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1042/files#diff-c28129781f5c1252730d5d7db543fb330700ab042e195163570fa9ad9bd461ca">+54/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>buffer.rs</strong><dd><code>Comprehensive Buffer Functionality and Error Handling Tests</code></dd></summary>
<hr>

src/tracing/packet/buffer.rs
<li>Added tests for immutable and mutable buffer functionalities.<br> <li> Included tests for debug representations of buffers.<br> <li> Added tests to ensure immutable buffers cannot be written to.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1042/files#diff-780a1890d8a831d07f96eafb565257fd66cfe70fc1e92a7de48c6aaa5e5ae3ae">+61/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>checksum.rs</strong><dd><code>Extended Checksum Calculation Tests for Edge Cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tracing/packet/checksum.rs
<li>Introduced tests for checksum calculations with empty payloads.<br> <li> Added a test for checksum calculation with an odd-length payload.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1042/files#diff-f30b7e9bd0abfab906c2b7fe2204dbc0d1f2bad55458cdd77bc921a719bb2554">+23/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>icmpv4.rs</strong><dd><code>Added Insufficient Buffer Size Tests for ICMPv4 Packets</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/tracing/packet/icmpv4.rs
- Added tests for insufficient buffer size during packet creation.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1042/files#diff-3d6598cba9c9b141e7efcabed4a80bbe175eb6ce75a420c1bc90ac27e29716ee">+142/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>icmpv6.rs</strong><dd><code>Added Insufficient Buffer Size Tests for ICMPv6 Packets</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/tracing/packet/icmpv6.rs
- Added tests for insufficient buffer size during packet creation.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1042/files#diff-7cb59b48e076d009d055a581e86237915e2860b6e503e053e90e0cb486378a85">+142/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ipv4.rs</strong><dd><code>Insufficient Buffer Size Handling Tests for IPv4 Packets</code>&nbsp; </dd></summary>
<hr>

src/tracing/packet/ipv4.rs
<li>Added tests for insufficient buffer size during IPv4 packet creation.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1042/files#diff-f2027844bb63d79cab966cec62e6d234a5d3deb1c2e20d78529869502088e34c">+22/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ipv6.rs</strong><dd><code>Insufficient Buffer Size Handling Tests for IPv6 Packets</code>&nbsp; </dd></summary>
<hr>

src/tracing/packet/ipv6.rs
<li>Added tests for insufficient buffer size during IPv6 packet creation.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1042/files#diff-1b8f8208f7736e7c2e0994b83a9a575088d058c1df971a412c148919332f1d9c">+22/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tcp.rs</strong><dd><code>Insufficient Buffer Size Handling Tests for TCP Packets</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/tracing/packet/tcp.rs
<li>Added tests for insufficient buffer size during TCP packet creation.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1042/files#diff-3380bd97671617f6b52d9f2c7c1665b430940f0d6d1d6888c4aa0385956bf1e3">+22/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>udp.rs</strong><dd><code>Insufficient Buffer Size Handling Tests for UDP Packets</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/tracing/packet/udp.rs
<li>Added tests for insufficient buffer size during UDP packet creation.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1042/files#diff-ccd45709ba5299fa184007cdb98f0206dd9b47361282068d96b7f485e5a4e8e0">+22/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>error.rs</strong><dd><code>Enhanced PacketError for Improved Testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tracing/packet/error.rs
<li>Made <code>PacketError</code> derive <code>Eq</code> and <code>PartialEq</code> for better error comparison <br>in tests.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1042/files#diff-1efa610ece7d0bcb7d75b0ae19455868975d3e9f5ce1280aec949d6ccf1f112c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

