### PR TITLE
fix(tui): Jitter display bug no response

### DIFF
--- a/src/frontend/render/table.rs
+++ b/src/frontend/render/table.rs
@@ -138,6 +138,7 @@ fn new_cell(
     config: &TuiConfig,
 ) -> Cell<'static> {
     let is_target = app.tracer_data().is_target(hop, app.selected_flow);
+    let total_recv = hop.total_recv();
     match column {
         Column::Ttl => render_usize_cell(hop.ttl().into()),
         Column::Host => {
@@ -151,16 +152,16 @@ fn new_cell(
         Column::LossPct => render_loss_pct_cell(hop),
         Column::Sent => render_usize_cell(hop.total_sent()),
         Column::Received => render_usize_cell(hop.total_recv()),
-        Column::Last => render_float_cell(hop.last_ms(), 1),
+        Column::Last => render_float_cell(hop.last_ms(), 1, total_recv),
         Column::Average => render_avg_cell(hop),
-        Column::Best => render_float_cell(hop.best_ms(), 1),
-        Column::Worst => render_float_cell(hop.worst_ms(), 1),
+        Column::Best => render_float_cell(hop.best_ms(), 1, total_recv),
+        Column::Worst => render_float_cell(hop.worst_ms(), 1, total_recv),
         Column::StdDev => render_stddev_cell(hop),
         Column::Status => render_status_cell(hop, is_target),
-        Column::Jitter => render_float_cell(hop.jitter_ms(), 1),
-        Column::Javg => render_float_cell(Some(hop.javg_ms()), 1),
-        Column::Jmax => render_float_cell(hop.jmax_ms(), 1),
-        Column::Jinta => render_float_cell(Some(hop.jinta()), 1),
+        Column::Jitter => render_float_cell(hop.jitter_ms(), 1, total_recv),
+        Column::Javg => render_float_cell(Some(hop.javg_ms()), 1, total_recv),
+        Column::Jmax => render_float_cell(hop.jmax_ms(), 1, total_recv),
+        Column::Jinta => render_float_cell(Some(hop.jinta()), 1, total_recv),
         Column::LastSrcPort => render_port_cell(hop.last_src_port()),
         Column::LastDestPort => render_port_cell(hop.last_dest_port()),
         Column::LastSeq => render_usize_cell(usize::from(hop.last_sequence())),
@@ -191,8 +192,12 @@ fn render_stddev_cell(hop: &Hop) -> Cell<'static> {
     })
 }
 
-fn render_float_cell(value: Option<f64>, places: usize) -> Cell<'static> {
-    Cell::from(value.map(|v| format!("{v:.places$}")).unwrap_or_default())
+fn render_float_cell(value: Option<f64>, places: usize, total_recv: usize) -> Cell<'static> {
+    Cell::from(if total_recv > 0 {
+        value.map(|v| format!("{v:.places$}")).unwrap_or_default()
+    } else {
+        String::default()
+    })
 }
 
 fn render_status_cell(hop: &Hop, is_target: bool) -> Cell<'static> {


### PR DESCRIPTION
## **User description**
Closes #1045 

## **User description**
Fix for bug 1045
Purpose:
Fixes a display issue for hops with "No Response" displaying "0.0" in the javg & jint columns.  The solution checks total_recv > 0 to use the value just like all the other columns do.


___

## **Type**
bug_fix


___

## **Description**
- Fixes a display issue where metrics like jitter and average were incorrectly shown for hops with no responses.
- Ensures that metrics are only displayed if there are received packets, improving the accuracy of the table display.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>table.rs</strong><dd><code>Fix Display of Jitter and Other Metrics for No Response Scenarios</code></dd></summary>
<hr>

src/frontend/render/table.rs
<li>Added <code>total_recv</code> variable to check the total packets received before <br>rendering float values.<br> <li> Modified <code>render_float_cell</code> function to accept <code>total_recv</code> and <br>conditionally format cell values based on it.<br> <li> Updated calls to <code>render_float_cell</code> in columns <code>Last</code>, <code>Best</code>, <code>Worst</code>, <br><code>Jitter</code>, <code>Javg</code>, <code>Jmax</code>, and <code>Jinta</code> to include <code>total_recv</code> check.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1046/files#diff-e8496d67e00ec06c450c8f6671c54c596683ad8c3619058464884854d3e1999c">+14/-9</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions


___

## **Type**
Bug fix


___

## **Description**
- Fixes a display issue where metrics like jitter and average were incorrectly shown for hops with no responses.
- Ensures that metrics are only displayed if there are received packets, improving the accuracy of the table display.
- Modified `render_float_cell` to conditionally display values, enhancing data representation for scenarios with no responses.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>table.rs</strong><dd><code>Fix Display of Jitter and Other Metrics for No Response Scenarios</code></dd></summary>
<hr>

src/frontend/render/table.rs
<li>Added a check for <code>total_recv</code> to conditionally render float values in <br>table cells.<br> <li> Modified <code>render_float_cell</code> function to accept <code>total_recv</code> and <br>conditionally format cell values based on it.<br> <li> Updated calls to <code>render_float_cell</code> in columns <code>Last</code>, <code>Best</code>, <code>Worst</code>, <br><code>Jitter</code>, <code>Javg</code>, <code>Jmax</code>, and <code>Jinta</code> to include <code>total_recv</code> check.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1046/files#diff-e8496d67e00ec06c450c8f6671c54c596683ad8c3619058464884854d3e1999c">+14/-9</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

