### PR TITLE
add source module tests

### DIFF
--- a/src/tracing/net/platform.rs
+++ b/src/tracing/net/platform.rs
@@ -17,6 +17,7 @@ mod windows;
 pub use self::windows::*;
 
 /// Platform specific operations.
+#[cfg_attr(test, mockall::automock)]
 pub trait Platform {
     /// Determine the required byte ordering for IPv4 header fields.
     fn byte_order_for_address(addr: IpAddr) -> TraceResult<Ipv4ByteOrder>;


### PR DESCRIPTION
## **Type**
tests, enhancement


___

## **Description**
- Added `mockall::automock` to the `Platform` trait to facilitate mocking for tests.
- Introduced extensive testing for `SourceAddr::discover` method, covering default port discovery, fixed destination port, fixed both source and destination ports, and interface lookup scenarios.
- Implemented tests for `SourceAddr::validate` to ensure correct behavior for both IPv4 and IPv6 addresses, including handling of invalid addresses.
- Employed `MockPlatform` and `MockSocket` to mock external dependencies in the testing environment.
- Added a static mutex (`MTX`) to ensure thread safety across tests.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>platform.rs</strong><dd><code>Add Mock Support to Platform Trait</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tracing/net/platform.rs
<li>Added <code>mockall::automock</code> attribute to the <code>Platform</code> trait for testing <br>purposes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1051/files#diff-3189b06a1e2ab72a46f88371555e2bf329467608824cb2f5146bf109e827a503">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>source.rs</strong><dd><code>Comprehensive Tests for SourceAddr Discovery and Validation</code></dd></summary>
<hr>

src/tracing/net/source.rs
<li>Implemented comprehensive tests for <code>SourceAddr::discover</code> covering <br>various scenarios.<br> <li> Added tests for <code>SourceAddr::validate</code> for both IPv4 and IPv6 addresses, <br>including error handling.<br> <li> Utilized <code>MockPlatform</code> and <code>MockSocket</code> for mocking dependencies in <br>tests.<br> <li> Ensured thread safety in tests using a static mutex.<br>


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1051/files#diff-f7b970f9fbd60c71c97afec9bd53cb6bf4e1a95b63d897e5b8ceb3315516bb0d">+177/-0</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

