### PR TITLE
fix: add snap plug `home` to allow accessing the configuration file from `/home`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,6 +56,7 @@ description: |
     - `network`: to allow general outgoing network access
     - `network-bind`: to allow binding to local ports
     - `network-observe`: to allow enabling `CAP_NET_RAW` for using raw sockets
+    - `home`: to allow access to /home for reading the configuraton file
 contact: mailto:fujiapple852@gmail.com
 issues: https://github.com/fujiapple852/trippy/issues
 license: Apache-2.0
@@ -74,3 +75,4 @@ apps:
       - network-bind
       - network
       - network-observe
+      - home


### PR DESCRIPTION
## **User description**
Supports #1058


___

## **Type**
enhancement


___

## **Description**
- Added the `home` plug to the Snap configuration to enable reading the configuration file from `/home`.
- This change allows the application to access necessary files in the user's home directory, enhancing its functionality and user experience.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snapcraft.yaml</strong><dd><code>Add `home` plug to Snap configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

snap/snapcraft.yaml
<li>Added <code>home</code> plug to allow access to <code>/home</code> for reading the configuration <br>file.<br> <li> Ensured <code>home</code> plug is included in the app's plugs list.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1059/files#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

