### PR TITLE
chore: clippy lints for Rust 1.77.0

### DIFF
--- a/src/frontend/render/table.rs
+++ b/src/frontend/render/table.rs
@@ -91,10 +91,7 @@ fn render_table_row(
     config: &TuiConfig,
     custom_columns: &Columns,
 ) -> Row<'static> {
-    let is_selected_hop = app
-        .selected_hop()
-        .map(|h| h.ttl() == hop.ttl())
-        .unwrap_or_default();
+    let is_selected_hop = app.selected_hop().is_some_and(|h| h.ttl() == hop.ttl());
     let is_in_round = app.tracer_data().is_in_round(hop, app.selected_flow);
     let (_, row_height) = if is_selected_hop && app.show_hop_details {
         render_hostname_with_details(app, hop, dns, geoip_lookup, config)

--- a/src/geoip.rs
+++ b/src/geoip.rs
@@ -311,8 +311,8 @@ impl GeoIpLookup {
     /// If an entry is found it is cached and returned, otherwise None is returned.
     pub fn lookup(&self, addr: IpAddr) -> anyhow::Result<Option<Rc<GeoIpCity>>> {
         if let Some(reader) = &self.reader {
-            if let Some(geo) = self.cache.borrow().get(&addr).map(Clone::clone) {
-                return Ok(Some(geo));
+            if let Some(geo) = self.cache.borrow().get(&addr) {
+                return Ok(Some(geo.clone()));
             }
             let city_data = if reader.metadata.database_type.starts_with("ipinfo") {
                 GeoIpCity::from(reader.lookup::<ipinfo::IpInfoGeoIp>(addr)?)


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Simplified the determination of a selected hop in the traceroute table rendering by using `is_some_and`.
- Improved the readability and efficiency of the GeoIP lookup cache access by using `cloned()` instead of `map(Clone::clone)`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>table.rs</strong><dd><code>Simplify Selected Hop Logic with `is_some_and`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/render/table.rs
<li>Simplified the logic to determine if a hop is selected using <br><code>is_some_and</code>.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1060/files#diff-e8496d67e00ec06c450c8f6671c54c596683ad8c3619058464884854d3e1999c">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>geoip.rs</strong><dd><code>Clean Up GeoIP Lookup Cache Access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/geoip.rs
<li>Replaced <code>map(Clone::clone)</code> with <code>cloned()</code> for cleaner code in <code>lookup</code> <br>method.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1060/files#diff-3cd845556a6c75f6b156a6bb301ba07290e948b3484ca190339d5312e0cd83f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

