### PR TITLE
fix: add snap plug `personal-files` to allow accessing a hidden confi…

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -76,3 +76,4 @@ apps:
       - network
       - network-observe
       - home
+      - personal-files


### PR DESCRIPTION
## **User description**
…guration file from `/home`


___

## **Type**
bug_fix


___

## **Description**
- Added the `personal-files` plug to the snap configuration to enable access to hidden configuration files in the user's home directory. This is a critical update for ensuring the application can fully function when distributed as a snap package.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snapcraft.yaml</strong><dd><code>Add `personal-files` plug for hidden config file access</code>&nbsp; &nbsp; </dd></summary>
<hr>

snap/snapcraft.yaml
<li>Added <code>personal-files</code> plug to allow accessing a hidden configuration <br>file from <code>/home</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1061/files#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

