### PR TITLE
Simulator improvements

### DIFF
--- a/tests/resources/simulation/ipv4_icmp_wrap.yaml
+++ b/tests/resources/simulation/ipv4_icmp_wrap.yaml
@@ -1,0 +1,35 @@
+name: IPv4/ICMP wrap sequence
+target: 10.0.0.107
+rounds: 10
+protocol: Icmp
+icmp_identifier: 8
+initial_sequence: 65000
+hops:
+  - ttl: 1
+    resp: !SingleHost
+      addr: 10.0.0.101
+      rtt_ms: 0
+  - ttl: 2
+    resp: !SingleHost
+      addr: 10.0.0.102
+      rtt_ms: 0
+  - ttl: 3
+    resp: !SingleHost
+      addr: 10.0.0.103
+      rtt_ms: 0
+  - ttl: 4
+    resp: !SingleHost
+      addr: 10.0.0.104
+      rtt_ms: 0
+  - ttl: 5
+    resp: !SingleHost
+      addr: 10.0.0.105
+      rtt_ms: 0
+  - ttl: 6
+    resp: !SingleHost
+      addr: 10.0.0.106
+      rtt_ms: 0
+  - ttl: 7
+    resp: !SingleHost
+      addr: 10.0.0.107
+      rtt_ms: 0

--- a/tests/sim/simulation.rs
+++ b/tests/sim/simulation.rs
@@ -6,6 +6,7 @@ use trippy::tracing::Port;
 #[derive(Debug, Deserialize)]
 pub struct Simulation {
     pub name: String,
+    pub rounds: Option<usize>,
     #[serde(default)]
     pub privilege_mode: PrivilegeMode,
     pub target: IpAddr,
@@ -16,6 +17,7 @@ pub struct Simulation {
     pub multipath_strategy: MultipathStrategy,
     #[serde(default)]
     pub icmp_identifier: u16,
+    pub initial_sequence: Option<u16>,
     pub packet_size: Option<u16>,
     pub payload_pattern: Option<u8>,
     pub min_round_duration: Option<u64>,

--- a/tests/sim/tests.rs
+++ b/tests/sim/tests.rs
@@ -41,6 +41,7 @@ macro_rules! sim {
 #[test_case(sim!("ipv4_icmp_min.yaml"))]
 #[test_case(sim!("ipv4_icmp_pattern.yaml"))]
 #[test_case(sim!("ipv4_icmp_quick.yaml"))]
+#[test_case(sim!("ipv4_icmp_wrap.yaml"))]
 #[test_case(sim!("ipv4_udp_classic_fixed_src.yaml"))]
 #[test_case(sim!("ipv4_udp_classic_fixed_dest.yaml"))]
 #[test_case(sim!("ipv4_udp_paris_fixed_both.yaml"))]

--- a/tests/sim/tests.rs
+++ b/tests/sim/tests.rs
@@ -63,11 +63,11 @@ fn run_simulation_with_retry(simulation: Simulation) -> anyhow::Result<()> {
     let name = simulation.name.clone();
     for attempt in 1..=MAX_ATTEMPTS {
         info!("start simulating {} [attempt #{}]", name, attempt);
-        if runtime.block_on(run_simulation(simulation.clone())).is_ok() {
+        if let Err(err) = runtime.block_on(run_simulation(simulation.clone())) {
+            error!("failed simulating {} {} [attempt #{}]", name, err, attempt);
+        } else {
             info!("end simulating {} [attempt #{}]", name, attempt);
             return Ok(());
-        } else {
-            error!("failed simulating {} [attempt #{}]", name, attempt);
         }
     }
     anyhow::bail!("failed simulating {} after {} attempts", name, MAX_ATTEMPTS)


### PR DESCRIPTION
## **Type**
enhancement, tests


___

## **Description**
- Introduced a read timeout in network simulation to prevent lock starvation.
- Added new simulation parameters `rounds` and `initial_sequence` for detailed control.
- Included a new simulation test case `ipv4_icmp_wrap.yaml` to validate the wrap sequence handling.
- Enhanced error logging in simulation tests for better debugging.
- Configured tracer to support new simulation parameters, allowing for more flexible test scenarios.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network.rs</strong><dd><code>Enhance Network Simulator with Read Timeout and Error Handling</code></dd></summary>
<hr>

tests/sim/network.rs
<li>Introduced a constant <code>READ_TIMEOUT</code> for network read operations.<br> <li> Implemented a new function <code>read_with_timeout</code> to prevent lock <br>starvation by adding a timeout to read operations.<br> <li> Modified the network simulation loop to use <code>read_with_timeout</code> for <br>reading from the tun device.<br> <li> Added a check to continue the loop if no bytes are read, improving <br>error handling.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1064/files#diff-21017eda8d4302989035ae2ed41b989e998fad0386fd67f9fc74ee11e9b96863">+16/-3</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>simulation.rs</strong><dd><code>Add Rounds and Initial Sequence Configuration to Simulation</code></dd></summary>
<hr>

tests/sim/simulation.rs
<li>Added <code>rounds</code> and <code>initial_sequence</code> as optional parameters to the <br><code>Simulation</code> struct.<br> <li> These additions allow for more detailed configuration of simulation <br>parameters.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1064/files#diff-bde83fe3e6550068c9ba47803875b35bb084c3fab1373fcc33c2b5f4edad46ea">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tracer.rs</strong><dd><code>Enhance Tracer with Initial Sequence and Rounds Configuration</code></dd></summary>
<hr>

tests/sim/tracer.rs
<li>Added handling for <code>initial_sequence</code> and <code>rounds</code> in the tracer <br>configuration.<br> <li> These changes allow the tracer to start with a specified sequence <br>number and limit the number of rounds.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1064/files#diff-54a803c9c8789e545e95a1137fa0fa38000742e1dfb23e4c9ed045bb0fea2152">+12/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.rs</strong><dd><code>Add New Simulation Test and Improve Error Logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sim/tests.rs
<li>Added a new simulation test case <code>ipv4_icmp_wrap.yaml</code>.<br> <li> Improved error logging in <code>run_simulation_with_retry</code> by including the <br>error message in the log.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1064/files#diff-aeca91743a15f4660220511a539534c9eba57750c719824d957d1d8dec292eae">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ipv4_icmp_wrap.yaml</strong><dd><code>Add New Simulation Configuration for IPv4/ICMP Wrap Sequence</code></dd></summary>
<hr>

tests/resources/simulation/ipv4_icmp_wrap.yaml
<li>Introduced a new simulation configuration <code>IPv4/ICMP wrap sequence</code>.<br> <li> Configures a simulation with specific <code>rounds</code>, <code>initial_sequence</code>, and <br>hop responses.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1064/files#diff-6829f47cb7fddf841db21e16211301582b8824aff12ee0a9cfaf2168d285c604">+35/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

