### PR TITLE
build: use `read: all` for snap `home` interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,4 +75,5 @@ apps:
       - network-bind
       - network
       - network-observe
-      - home
+      - home:
+          read: all


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Enhanced the snap permissions by specifying `read: all` for the `home` interface in `snapcraft.yaml`. This allows the application to have read access to all user files.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snapcraft.yaml</strong><dd><code>Enhance Snap Permissions for Home Interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

snap/snapcraft.yaml
- Added `read: all` permission to the `home` interface.



</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1066/files#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

