### PR TITLE
feat(net): reduce `MAX_SEQUENCE_PER_ROUND` from 1024 to 512 (#1067)

### DIFF
--- a/src/tracing/constants.rs
+++ b/src/tracing/constants.rs
@@ -6,7 +6,7 @@ pub const MAX_TTL: u8 = 254;
 /// This is set to be far larger than the `MAX_TTL` to allow for the re-issue of probes (with the
 /// next sequence number, but the same ttl) which can occur for some protocols such as TCP when it
 /// cannot bind to a given port.
-pub const MAX_SEQUENCE_PER_ROUND: u16 = 1024;
+pub const MAX_SEQUENCE_PER_ROUND: u16 = 512;
 
 /// The maximum _starting_ sequence number allowed.
 ///

--- a/src/tracing/tracer.rs
+++ b/src/tracing/tracer.rs
@@ -1090,8 +1090,8 @@ mod state {
                 state.advance_round(TimeToLive(1));
             }
             assert_eq!(state.round, Round(2000));
-            assert_eq!(state.round_sequence, Sequence(33000));
-            assert_eq!(state.sequence, Sequence(33000));
+            assert_eq!(state.round_sequence, Sequence(57130));
+            assert_eq!(state.sequence, Sequence(57130));
         }
 
         #[test]
@@ -1121,16 +1121,16 @@ mod state {
                 state.advance_round(TimeToLive(1));
             }
             assert_eq!(state.round, Round(2000));
-            assert_eq!(state.round_sequence, Sequence(56876));
-            assert_eq!(state.sequence, Sequence(56876));
+            assert_eq!(state.round_sequence, Sequence(41128));
+            assert_eq!(state.sequence, Sequence(41128));
         }
 
         #[test]
         fn test_in_round() {
             let state = TracerState::new(cfg(Sequence(33000)));
             assert!(state.in_round(Sequence(33000)));
-            assert!(state.in_round(Sequence(34023)));
-            assert!(!state.in_round(Sequence(34024)));
+            assert!(state.in_round(Sequence(33511)));
+            assert!(!state.in_round(Sequence(33512)));
         }
 
         #[test]


### PR DESCRIPTION
## **User description**
Closes #1067


___

## **Type**
enhancement


___

## **Description**
- Reduced the `MAX_SEQUENCE_PER_ROUND` from 1024 to 512 in `src/tracing/constants.rs` to improve efficiency.
- Updated test cases in `src/tracing/tracer.rs` to align with the new max sequence per round value, ensuring consistency and correctness.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constants.rs</strong><dd><code>Reduce Max Sequence Per Round for Efficiency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tracing/constants.rs
- Reduced `MAX_SEQUENCE_PER_ROUND` from 1024 to 512.



</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1068/files#diff-cd9becc072e832a8ac74e9d87d755dab03503f5eaa037af1b737bf6ff504b366">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tracer.rs</strong><dd><code>Update Tracer Tests for New Max Sequence Value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tracing/tracer.rs
<li>Adjusted test cases to reflect the new <code>MAX_SEQUENCE_PER_ROUND</code> value.<br> <li> Updated sequence numbers in test cases to align with the reduced max <br>sequence per round.<br>


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1068/files#diff-de8cda5bbbcfac9883641740579ad71fda582148e86231586d12178713578bd3">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

