### PR TITLE
fix: move snap plug `home` configuration to top level `plugs`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,5 +75,7 @@ apps:
       - network-bind
       - network
       - network-observe
-      - home:
-          read: all
+      - home
+plugs:
+  home:
+    read: all


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Moved the `home` plug configuration from the `apps` section to the top-level `plugs` section in `snapcraft.yaml`.
- This change ensures that the `home` plug is correctly configured with `read: all` permissions, enhancing the application's access management.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snapcraft.yaml</strong><dd><code>Refactor Snap `home` Plug Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

snap/snapcraft.yaml
<li>Moved <code>home</code> plug configuration to the top-level <code>plugs</code> section.<br> <li> Ensured <code>home</code> plug has <code>read: all</code> permissions.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1072/files#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

