### PR TITLE
Chore update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.10.0] - 2024-03-31
+
+### Added
+
 - Added support for calculating and displaying jitter ([#39](https://github.com/fujiapple852/trippy/issues/39))
 - Added support for customizing columns ([#757](https://github.com/fujiapple852/trippy/issues/757))
 - Added support for reordering and toggling column
@@ -318,7 +326,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial WIP release of `trippy`
 
-[Unreleased]: https://github.com/fujiapple852/trippy/compare/0.9.0...master
+[Unreleased]: https://github.com/fujiapple852/trippy/compare/0.10.0...master
+
+[0.10.0]: https://github.com/fujiapple852/trippy/compare/0.9.0...0.10.0
 
 [0.9.0]: https://github.com/fujiapple852/trippy/compare/0.8.0...0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added support for calculating and displaying jitter ([#39](https://github.com/fujiapple852/trippy/issues/39))
 - Added support for customizing columns ([#757](https://github.com/fujiapple852/trippy/issues/757))
+- Added support for reordering and toggling column
+  visibility in Tui ([#1026](https://github.com/fujiapple852/trippy/issues/1026))
+- Added support for [dublin](https://github.com/insomniacslk/dublin-traceroute) ECMP routing
+  for `IPv6/udp` ([#272](https://github.com/fujiapple852/trippy/issues/272))
 - Added support for [IPinfo](https://ipinfo.io) flavoured `mmdb`
   files ([#862](https://github.com/fujiapple852/trippy/issues/862))
 - Added support for `IPv4->IPv6` and `IPv6->IPv4` DNS fallback
@@ -29,6 +33,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Restrict flows to `paris` and `dublin` ECMP strategies ([#1007](https://github.com/fujiapple852/trippy/issues/1007))
 - Improved Tui table column layout logic ([#925](https://github.com/fujiapple852/trippy/issues/925))
 - Use exclusive reference `&mut` for all Socket operations ([#843](https://github.com/fujiapple852/trippy/issues/843))
+- Reduced maximum sequence per round from 1024 to 512 ([#1067](https://github.com/fujiapple852/trippy/issues/1067))
 
 ### Fixed
 


### PR DESCRIPTION
## **Type**
enhancement, documentation


___

## **Description**
- Updated `CHANGELOG.md` to include new features, improvements, and fixes for the upcoming 0.10.0 release.
- Notable additions include support for reordering and toggling column visibility in Tui, dublin ECMP routing for IPv6/udp, and a reduction in the maximum sequence per round.
- Adjusted the comparison links to reflect the latest version.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update CHANGELOG for Version 0.10.0 Release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md
<li>Added entries for new features, improvements, and fixes in version <br>0.10.0.<br> <li> Introduced support for reordering and toggling column visibility, <br>dublin ECMP routing for IPv6/udp, and reduced maximum sequence per <br>round.<br> <li> Updated the comparison links for unreleased and released versions.


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1077/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+16/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

