### PR TITLE
build: add `CROSS_NO_WARNINGS: 0` to restore prior cross fallback behaviour

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
       CARGO: cargo
       TARGET_FLAGS: ""
       TARGET_DIR: ./target
+      CROSS_NO_WARNINGS: 0
       RUST_BACKTRACE: 1
     strategy:
       matrix:


### PR DESCRIPTION
## **User description**
See https://github.com/cross-rs/cross/issues/1447


___

## **Type**
enhancement


___

## **Description**
- Added `CROSS_NO_WARNINGS: 0` to the GitHub Actions release workflow to address the issue with cross fallback behavior as discussed in https://github.com/cross-rs/cross/issues/1447. This change ensures that warnings from the `cross` tool do not interfere with the build process.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Add CROSS_NO_WARNINGS to GitHub Actions Release Workflow</code>&nbsp; </dd></summary>
<hr>

.github/workflows/release.yml
<li>Added <code>CROSS_NO_WARNINGS: 0</code> environment variable to the release <br>workflow to restore previous cross fallback behavior.<br>


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1080/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

