### PR TITLE
chore: added #1058 to `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed tracer not discarding unrelated `icmp` packets for `udp` and `tcp`
   protocols ([#982](https://github.com/fujiapple852/trippy/issues/982))
 - Fixed incorrect minimum packet size for `IPv6` ([#985](https://github.com/fujiapple852/trippy/issues/985))
+- Fixed permission denied error reading configuration file from snap
+  installation ([#1058](https://github.com/fujiapple852/trippy/issues/1058))
 
 ## [0.9.0] - 2023-11-30
 


### PR DESCRIPTION
## **Type**
documentation


___

## **Description**
- Added a new entry in the CHANGELOG.md to document the fix for a permission denied error when reading the configuration file from a snap installation.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update CHANGELOG for Snap Installation Fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md
<li>Added entry for fixing permission denied error when reading <br>configuration file from snap installation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/fujiapple852/trippy/pull/1081/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

