### PR TITLE
build: update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,20 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+        - dependency-name: "clap*"
+          update-types:
+            - "version-update:semver-patch"
+        - dependency-name: "serde*"
+          update-types:
+            - "version-update:semver-patch"
+        - dependency-name: "anyhow"
+          update-types:
+            - "version-update:semver-patch"
+        - dependency-name: "thiserror"
+          update-types:
+            - "version-update:semver-patch"
+    allow:
+      - dependency-type: "all"
     open-pull-requests-limit: 10
+    rebase-strategy: "disabled"


### PR DESCRIPTION
- ignore patch update to all `serde*`, `clap*`, `anyhow` and `thiserror` crates
- include updates to transitive dependencies in `Cargo.lock` file
- disable auto rebasing of PRs