### PR TITLE
fix: remove documentation link from most crates

### DIFF
--- a/crates/trippy-core/Cargo.toml
+++ b/crates/trippy-core/Cargo.toml
@@ -3,7 +3,6 @@ name = "trippy-core"
 description = "A network tracing library"
 version.workspace = true
 authors.workspace = true
-documentation.workspace = true
 homepage.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/crates/trippy-dns/Cargo.toml
+++ b/crates/trippy-dns/Cargo.toml
@@ -3,7 +3,6 @@ name = "trippy-dns"
 description = "A lazy DNS resolver for Trippy"
 version.workspace = true
 authors.workspace = true
-documentation.workspace = true
 homepage.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/crates/trippy-packet/Cargo.toml
+++ b/crates/trippy-packet/Cargo.toml
@@ -3,7 +3,6 @@ name = "trippy-packet"
 description = "Network packets for Trippy"
 version.workspace = true
 authors.workspace = true
-documentation.workspace = true
 homepage.workspace = true
 repository.workspace = true
 readme.workspace = true

--- a/crates/trippy-privilege/Cargo.toml
+++ b/crates/trippy-privilege/Cargo.toml
@@ -3,7 +3,6 @@ name = "trippy-privilege"
 description = "Discover platform privileges"
 version.workspace = true
 authors.workspace = true
-documentation.workspace = true
 homepage.workspace = true
 repository.workspace = true
 readme.workspace = true


### PR DESCRIPTION
Cargo will link to docs.rs instead