### PR TITLE
Reimplement packets using zero copy with bytemuck crate

### DIFF
--- a/crates/trippy-packet/Cargo.toml
+++ b/crates/trippy-packet/Cargo.toml
@@ -15,6 +15,7 @@ categories.workspace = true
 [dependencies]
 itertools.workspace = true
 thiserror.workspace = true
+bytemuck = "1.9.1"
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/trippy-packet/src/icmp_extension.rs
+++ b/crates/trippy-packet/src/icmp_extension.rs
@@ -1302,3 +1302,9 @@ pub mod extension_splitter {
         }
     }
 }
+                assert_eq!(8, extension_object.get_length());
+                assert_eq!(8, extension_object.get_length());
+                assert_eq!(8, extension_object.get_length());
+                assert_eq!(8, extension_object.get_length());
+                assert_eq!(8, extension_object.get_length());
+                assert_eq!(8, extension_object.get_length());

--- a/crates/trippy-packet/src/ipv4.rs
+++ b/crates/trippy-packet/src/ipv4.rs
@@ -1,36 +1,35 @@
-use crate::buffer::Buffer;
 use crate::error::{Error, Result};
-use crate::{fmt_payload, IpProtocol};
+use bytemuck::{Pod, Zeroable};
 use std::fmt::{Debug, Formatter};
 use std::net::Ipv4Addr;
+use crate::{fmt_payload, IpProtocol};
 
-const VERSION_OFFSET: usize = 0;
-const IHL_OFFSET: usize = 0;
-const DSCP_OFFSET: usize = 1;
-const ECN_OFFSET: usize = 1;
-const TOTAL_LENGTH_OFFSET: usize = 2;
-const IDENTIFICATION_OFFSET: usize = 4;
-const FLAGS_AND_FRAGMENT_OFFSET_OFFSET: usize = 6;
-const TIME_TO_LIVE_OFFSET: usize = 8;
-const PROTOCOL_OFFSET: usize = 9;
-const CHECKSUM_OFFSET: usize = 10;
-const SOURCE_OFFSET: usize = 12;
-const DESTINATION_OFFSET: usize = 16;
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, Zeroable)]
+pub struct Ipv4Header {
+    pub version_ihl: u8,
+    pub dscp_ecn: u8,
+    pub total_length: u16,
+    pub identification: u16,
+    pub flags_fragment_offset: u16,
+    pub ttl: u8,
+    pub protocol: u8,
+    pub checksum: u16,
+    pub source: [u8; 4],
+    pub destination: [u8; 4],
+}
 
-/// Represents an IPv4 Packet.
-///
-/// The internal representation is held in network byte order (big-endian) and all accessor methods
-/// take and return data in host byte order, converting as necessary for the given architecture.
 pub struct Ipv4Packet<'a> {
-    buf: Buffer<'a>,
+    header: &'a mut Ipv4Header,
+    payload: &'a mut [u8],
 }
 
 impl<'a> Ipv4Packet<'a> {
-    pub fn new(packet: &'a mut [u8]) -> Result<Self> {
-        if packet.len() >= Self::minimum_packet_size() {
-            Ok(Self {
-                buf: Buffer::Mutable(packet),
-            })
+    pub fn new(packet: &'a mut [u8]) -> Result<Ipv4Packet<'a>> {
+        if packet.len() >= Ipv4Packet::minimum_packet_size() {
+            let (header_bytes, payload) = packet.split_at_mut(std::mem::size_of::<Ipv4Header>());
+            let header = bytemuck::from_bytes_mut(header_bytes);
+            Ok(Ipv4Packet { header, payload })
         } else {
             Err(Error::InsufficientPacketBuffer(
                 String::from("Ipv4Packet"),
@@ -40,11 +39,11 @@ impl<'a> Ipv4Packet<'a> {
         }
     }
 
-    pub fn new_view(packet: &'a [u8]) -> Result<Self> {
-        if packet.len() >= Self::minimum_packet_size() {
-            Ok(Self {
-                buf: Buffer::Immutable(packet),
-            })
+    pub fn new_view(packet: &'a [u8]) -> Result<Ipv4Packet<'a>> {
+        if packet.len() >= Ipv4Packet::minimum_packet_size() {
+            let (header_bytes, payload) = packet.split_at(std::mem::size_of::<Ipv4Header>());
+            let header = bytemuck::from_bytes_mut(header_bytes);
+            Ok(Ipv4Packet { header, payload })
         } else {
             Err(Error::InsufficientPacketBuffer(
                 String::from("Ipv4Packet"),
@@ -56,67 +55,7 @@ impl<'a> Ipv4Packet<'a> {
 
     #[must_use]
     pub const fn minimum_packet_size() -> usize {
-        20
-    }
-
-    #[must_use]
-    pub fn get_version(&self) -> u8 {
-        (self.buf.read(VERSION_OFFSET) & 0xf0) >> 4
-    }
-
-    #[must_use]
-    pub fn get_header_length(&self) -> u8 {
-        self.buf.read(IHL_OFFSET) & 0xf
-    }
-
-    #[must_use]
-    pub fn get_dscp(&self) -> u8 {
-        (self.buf.read(DSCP_OFFSET) & 0xfc) >> 2
-    }
-
-    #[must_use]
-    pub fn get_ecn(&self) -> u8 {
-        self.buf.read(ECN_OFFSET) & 0x3
-    }
-
-    #[must_use]
-    pub fn get_total_length(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes(TOTAL_LENGTH_OFFSET))
-    }
-
-    #[must_use]
-    pub fn get_identification(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes(IDENTIFICATION_OFFSET))
-    }
-
-    #[must_use]
-    pub fn get_flags_and_fragment_offset(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes(FLAGS_AND_FRAGMENT_OFFSET_OFFSET))
-    }
-
-    #[must_use]
-    pub fn get_ttl(&self) -> u8 {
-        self.buf.read(TIME_TO_LIVE_OFFSET)
-    }
-
-    #[must_use]
-    pub fn get_protocol(&self) -> IpProtocol {
-        IpProtocol::from(self.buf.read(PROTOCOL_OFFSET))
-    }
-
-    #[must_use]
-    pub fn get_checksum(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
-    }
-
-    #[must_use]
-    pub fn get_source(&self) -> Ipv4Addr {
-        Ipv4Addr::from(self.buf.get_bytes(SOURCE_OFFSET))
-    }
-
-    #[must_use]
-    pub fn get_destination(&self) -> Ipv4Addr {
-        Ipv4Addr::from(self.buf.get_bytes(DESTINATION_OFFSET))
+        std::mem::size_of::<Ipv4Header>()
     }
 
     #[must_use]
@@ -124,59 +63,9 @@ impl<'a> Ipv4Packet<'a> {
         let current_offset = Self::minimum_packet_size();
         let end = std::cmp::min(
             current_offset + ipv4_options_length(self),
-            self.buf.as_slice().len(),
+            self.payload.len(),
         );
-        &self.buf.as_slice()[current_offset..end]
-    }
-
-    pub fn set_version(&mut self, val: u8) {
-        *self.buf.write(VERSION_OFFSET) =
-            (self.buf.read(VERSION_OFFSET) & 0xf) | ((val & 0xf) << 4);
-    }
-
-    pub fn set_header_length(&mut self, val: u8) {
-        *self.buf.write(IHL_OFFSET) = (self.buf.read(IHL_OFFSET) & 0xf0) | (val & 0xf);
-    }
-
-    pub fn set_dscp(&mut self, val: u8) {
-        *self.buf.write(DSCP_OFFSET) = (self.buf.read(DSCP_OFFSET) & 0x3) | ((val & 0x3f) << 2);
-    }
-
-    pub fn set_ecn(&mut self, val: u8) {
-        *self.buf.write(ECN_OFFSET) = (self.buf.read(ECN_OFFSET) & 0xfc) | (val & 0x3);
-    }
-
-    pub fn set_total_length(&mut self, val: u16) {
-        self.buf.set_bytes(TOTAL_LENGTH_OFFSET, val.to_be_bytes());
-    }
-
-    pub fn set_identification(&mut self, val: u16) {
-        self.buf.set_bytes(IDENTIFICATION_OFFSET, val.to_be_bytes());
-    }
-
-    pub fn set_flags_and_fragment_offset(&mut self, val: u16) {
-        self.buf
-            .set_bytes(FLAGS_AND_FRAGMENT_OFFSET_OFFSET, val.to_be_bytes());
-    }
-
-    pub fn set_ttl(&mut self, val: u8) {
-        *self.buf.write(TIME_TO_LIVE_OFFSET) = val;
-    }
-
-    pub fn set_protocol(&mut self, val: IpProtocol) {
-        *self.buf.write(PROTOCOL_OFFSET) = val.id();
-    }
-
-    pub fn set_checksum(&mut self, val: u16) {
-        self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
-    }
-
-    pub fn set_source(&mut self, val: Ipv4Addr) {
-        self.buf.set_bytes(SOURCE_OFFSET, val.octets());
-    }
-
-    pub fn set_destination(&mut self, val: Ipv4Addr) {
-        self.buf.set_bytes(DESTINATION_OFFSET, val.octets());
+        &self.payload[current_offset..end]
     }
 
     pub fn get_options_raw_mut(&mut self) -> &mut [u8] {
@@ -184,50 +73,50 @@ impl<'a> Ipv4Packet<'a> {
         let current_offset = Self::minimum_packet_size();
         let end = min(
             current_offset + ipv4_options_length(self),
-            self.buf.as_slice().len(),
+            self.payload.len(),
         );
-        &mut self.buf.as_slice_mut()[current_offset..end]
+        &mut self.payload[current_offset..end]
     }
 
     pub fn set_payload(&mut self, vals: &[u8]) {
         let current_offset = Self::minimum_packet_size() + ipv4_options_length(self);
-        self.buf.as_slice_mut()[current_offset..current_offset + vals.len()].copy_from_slice(vals);
+        self.payload[current_offset..current_offset + vals.len()].copy_from_slice(vals);
     }
 
     #[must_use]
     pub fn packet(&self) -> &[u8] {
-        self.buf.as_slice()
+        unsafe { std::slice::from_raw_parts(self.header as *const _ as *const u8, self.payload.len() + std::mem::size_of::<Ipv4Header>()) }
     }
 
     #[must_use]
     pub fn payload(&self) -> &[u8] {
         let start = Ipv4Packet::minimum_packet_size() + ipv4_options_length(self);
-        &self.buf.as_slice()[start..]
+        &self.payload[start..]
     }
 }
 
 fn ipv4_options_length(ipv4: &Ipv4Packet<'_>) -> usize {
-    (ipv4.get_header_length() as usize * 4).saturating_sub(Ipv4Packet::minimum_packet_size())
+    (ipv4.header.version_ihl as usize * 4).saturating_sub(Ipv4Packet::minimum_packet_size())
 }
 
 impl Debug for Ipv4Packet<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Ipv4Packet")
-            .field("version", &self.get_version())
-            .field("header_length", &self.get_header_length())
-            .field("dscp", &self.get_dscp())
-            .field("ecn", &self.get_ecn())
-            .field("total_length", &self.get_total_length())
-            .field("identification", &self.get_identification())
+            .field("version", &((self.header.version_ihl & 0xf0) >> 4))
+            .field("header_length", &(self.header.version_ihl & 0xf))
+            .field("dscp", &((self.header.dscp_ecn & 0xfc) >> 2))
+            .field("ecn", &(self.header.dscp_ecn & 0x3))
+            .field("total_length", &self.header.total_length)
+            .field("identification", &self.header.identification)
             .field(
                 "flags_and_fragment_offset",
-                &self.get_flags_and_fragment_offset(),
+                &self.header.flags_fragment_offset,
             )
-            .field("ttl", &self.get_ttl())
-            .field("protocol", &self.get_protocol())
-            .field("checksum", &self.get_checksum())
-            .field("source", &self.get_source())
-            .field("destination", &self.get_destination())
+            .field("ttl", &self.header.ttl)
+            .field("protocol", &IpProtocol::from(self.header.protocol))
+            .field("checksum", &self.header.checksum)
+            .field("source", &Ipv4Addr::from(self.header.source))
+            .field("destination", &Ipv4Addr::from(self.header.destination))
             .field("options_raw", &self.get_options_raw())
             .field("payload", &fmt_payload(self.payload()))
             .finish()
@@ -242,11 +131,11 @@ mod tests {
     fn test_version() {
         let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
         let mut packet = Ipv4Packet::new(&mut buf).unwrap();
-        packet.set_version(4);
-        assert_eq!(4, packet.get_version());
+        packet.header.version_ihl = (packet.header.version_ihl & 0xf) | ((4 & 0xf) << 4);
+        assert_eq!(4, (packet.header.version_ihl & 0xf0) >> 4);
         assert_eq!([0x40], packet.packet()[..1]);
-        packet.set_version(15);
-        assert_eq!(15, packet.get_version());
+        packet.header.version_ihl = (packet.header.version_ihl & 0xf) | ((15 & 0xf) << 4);
+        assert_eq!(15, (packet.header.version_ihl & 0xf0) >> 4);
         assert_eq!([0xF0], packet.packet()[..1]);
     }
 
@@ -254,11 +143,11 @@ mod tests {
     fn test_header_length() {
         let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
         let mut packet = Ipv4Packet::new(&mut buf).unwrap();
-        packet.set_header_length(5);
-        assert_eq!(5, packet.get_header_length());
+        packet.header.version_ihl = (packet.header.version_ihl & 0xf0) | (5 & 0xf);
+        assert_eq!(5, packet.header.version_ihl & 0xf);
         assert_eq!([0x05], packet.packet()[..1]);
-        packet.set_header_length(15);
-        assert_eq!(15, packet.get_header_length());
+        packet.header.version_ihl = (packet.header.version_ihl & 0xf0) | (15 & 0xf);
+        assert_eq!(15, packet.header.version_ihl & 0xf);
         assert_eq!([0x0F], packet.packet()[..1]);
     }
 
@@ -266,15 +155,15 @@ mod tests {
     fn test_version_and_header_length() {
         let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
         let mut packet = Ipv4Packet::new(&mut buf).unwrap();
-        packet.set_version(4);
-        packet.set_header_length(5);
-        assert_eq!(4, packet.get_version());
-        assert_eq!(5, packet.get_header_length());
+        packet.header.version_ihl = (packet.header.version_ihl & 0xf) | ((4 & 0xf) << 4);
+        packet.header.version_ihl = (packet.header.version_ihl & 0xf0) | (5 & 0xf);
+        assert_eq!(4, (packet.header.version_ihl & 0xf0) >> 4);
+        assert_eq!(5, packet.header.version_ihl & 0xf);
         assert_eq!([0x45], packet.packet()[..1]);
-        packet.set_version(15);
-        packet.set_header_length(15);
-        assert_eq!(15, packet.get_version());
-        assert_eq!(15, packet.get_header_length());
+        packet.header.version_ihl = (packet.header.version_ihl & 0xf) | ((15 & 0xf) << 4);
+        packet.header.version_ihl = (packet.header.version_ihl & 0xf0) | (15 & 0xf);
+        assert_eq!(15, (packet.header.version_ihl & 0xf0) >> 4);
+        assert_eq!(15, packet.header.version_ihl & 0xf);
         assert_eq!([0xFF], packet.packet()[..1]);
     }
 
@@ -282,8 +171,8 @@ mod tests {
     fn test_dscp() {
         let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
         let mut packet = Ipv4Packet::new(&mut buf).unwrap();
-        packet.set_dscp(63);
-        assert_eq!(63, packet.get_dscp());
+        packet.header.dscp_ecn = (packet.header.dscp_ecn & 0x3) | ((63 & 0x3f) << 2);
+        assert_eq!(63, (packet.header.dscp_ecn & 0xfc) >> 2);
         assert_eq!([0x00, 0xFC], packet.packet()[..2]);
     }
 
@@ -291,8 +180,8 @@ mod tests {
     fn test_ecn() {
         let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
         let mut packet = Ipv4Packet::new(&mut buf).unwrap();
-        packet.set_ecn(3);
-        assert_eq!(3, packet.get_ecn());
+        packet.header.dscp_ecn = (packet.header.dscp_ecn & 0xfc) | (3 & 0x3);
+        assert_eq!(3, packet.header.dscp_ecn & 0x3);
         assert_eq!([0x00, 0x03], packet.packet()[..2]);
     }
 
@@ -300,10 +189,10 @@ mod tests {
     fn test_dscp_and_ecn() {
         let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
         let mut packet = Ipv4Packet::new(&mut buf).unwrap();
-        packet.set_dscp(63);
-        packet.set_ecn(3);
-        assert_eq!(63, packet.get_dscp());
-        assert_eq!(3, packet.get_ecn());
+        packet.header.dscp_ecn = (packet.header.dscp_ecn & 0x3) | ((63 & 0x3f) << 2);
+        packet.header.dscp_ecn = (packet.header.dscp_ecn & 0xfc) | (3 & 0x3);
+        assert_eq!(63, (packet.header.dscp_ecn & 0xfc) >> 2);
+        assert_eq!(3, packet.header.dscp_ecn & 0x3);
         assert_eq!([0x00, 0xFF], packet.packet()[..2]);
     }
 
@@ -311,11 +200,11 @@ mod tests {
     fn test_total_length() {
         let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
         let mut packet = Ipv4Packet::new(&mut buf).unwrap();
-        packet.set_total_length(84);
-        assert_eq!(84, packet.get_total_length());
+        packet.header.total_length = 84;
+        assert_eq!(84, packet.header.total_length);
         assert_eq!([0x00, 0x54], packet.packet()[2..=3]);
-        packet.set_total_length(65535);
-        assert_eq!(65535, packet.get_total_length());
+        packet.header.total_length = 65535;
+        assert_eq!(65535, packet.header.total_length);
         assert_eq!([0xFF, 0xFF], packet.packet()[2..=3]);
     }
 
@@ -323,11 +212,11 @@ mod tests {
     fn test_identification() {
         let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
         let mut packet = Ipv4Packet::new(&mut buf).unwrap();
-        packet.set_identification(32);
-        assert_eq!(32, packet.get_identification());
+        packet.header.identification = 32;
+        assert_eq!(32, packet.header.identification);
         assert_eq!([0x00, 0x20], packet.packet()[4..=5]);
-        packet.set_identification(u16::MAX);
-        assert_eq!(u16::MAX, packet.get_identification());
+        packet.header.identification = u16::MAX;
+        assert_eq!(u16::MAX, packet.header.identification);
         assert_eq!([0xFF, 0xFF], packet.packet()[4..=5]);
     }
 
@@ -335,12 +224,12 @@ mod tests {
     fn test_flags() {
         let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
         let mut packet = Ipv4Packet::new(&mut buf).unwrap();
-        packet.set_flags_and_fragment_offset(0);
-        assert_eq!(0, packet.get_flags_and_fragment_offset());
+        packet.header.flags_fragment_offset = 0;
+        assert_eq!(0, packet.header.flags_fragment_offset);
         assert_eq!([0x00, 0x00], packet.packet()[6..=7]);
         // The Don't Fragment (DF) bit set:
-        packet.set_flags_and_fragment_offset(0x4000);
-        assert_eq!(0x4000, packet.get_flags_and_fragment_offset());
+        packet.header.flags_fragment_offset = 0x4000;
+        assert_eq!(0x4000, packet.header.flags_fragment_offset);
         assert_eq!([0x40, 0x00], packet.packet()[6..=7]);
     }
 
@@ -348,11 +237,11 @@ mod tests {
     fn test_time_to_live() {
         let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
         let mut packet = Ipv4Packet::new(&mut buf).unwrap();
-        packet.set_ttl(16);
-        assert_eq!(16, packet.get_ttl());
+        packet.header.ttl = 16;
+        assert_eq!(16, packet.header.ttl);
         assert_eq!([0x10], packet.packet()[8..9]);
-        packet.set_ttl(u8::MAX);
-        assert_eq!(u8::MAX, packet.get_ttl());
+        packet.header.ttl = u8::MAX;
+        assert_eq!(u8::MAX, packet.header.ttl);
         assert_eq!([0xFF], packet.packet()[8..9]);
     }
 
@@ -360,23 +249,23 @@ mod tests {
     fn test_protocol() {
         let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
         let mut packet = Ipv4Packet::new(&mut buf).unwrap();
-        packet.set_protocol(IpProtocol::Icmp);
-        assert_eq!(IpProtocol::Icmp, packet.get_protocol());
+        packet.header.protocol = IpProtocol::Icmp.id();
+        assert_eq!(IpProtocol::Icmp, IpProtocol::from(packet.header.protocol));
         assert_eq!([0x01], packet.packet()[9..10]);
-        packet.set_protocol(IpProtocol::IcmpV6);
-        assert_eq!(IpProtocol::IcmpV6, packet.get_protocol());
+        packet.header.protocol = IpProtocol::IcmpV6.id();
+        assert_eq!(IpProtocol::IcmpV6, IpProtocol::from(packet.header.protocol));
         assert_eq!([0x3A], packet.packet()[9..10]);
-        packet.set_protocol(IpProtocol::Udp);
-        assert_eq!(IpProtocol::Udp, packet.get_protocol());
+        packet.header.protocol = IpProtocol::Udp.id();
+        assert_eq!(IpProtocol::Udp, IpProtocol::from(packet.header.protocol));
         assert_eq!([0x11], packet.packet()[9..10]);
-        packet.set_protocol(IpProtocol::Tcp);
-        assert_eq!(IpProtocol::Tcp, packet.get_protocol());
+        packet.header.protocol = IpProtocol::Tcp.id();
+        assert_eq!(IpProtocol::Tcp, IpProtocol::from(packet.header.protocol));
         assert_eq!([0x06], packet.packet()[9..10]);
-        packet.set_protocol(IpProtocol::Other(123));
-        assert_eq!(IpProtocol::Other(123), packet.get_protocol());
+        packet.header.protocol = IpProtocol::Other(123).id();
+        assert_eq!(IpProtocol::Other(123), IpProtocol::from(packet.header.protocol));
         assert_eq!([0x7B], packet.packet()[9..10]);
-        packet.set_protocol(IpProtocol::Other(255));
-        assert_eq!(IpProtocol::Other(255), packet.get_protocol());
+        packet.header.protocol = IpProtocol::Other(255).id();
+        assert_eq!(IpProtocol::Other(255), IpProtocol::from(packet.header.protocol));
         assert_eq!([0xFF], packet.packet()[9..10]);
     }
 
@@ -384,32 +273,32 @@ mod tests {
     fn test_header_checksum() {
         let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
         let mut packet = Ipv4Packet::new(&mut buf).unwrap();
-        packet.set_checksum(0);
-        assert_eq!(0, packet.get_checksum());
+        packet.header.checksum = 0;
+        assert_eq!(0, packet.header.checksum);
         assert_eq!([0x00, 0x00], packet.packet()[10..=11]);
-        packet.set_checksum(12345);
-        assert_eq!(12345, packet.get_checksum());
+        packet.header.checksum = 12345;
+        assert_eq!(12345, packet.header.checksum);
         assert_eq!([0x30, 0x39], packet.packet()[10..=11]);
-        packet.set_checksum(u16::MAX);
-        assert_eq!(u16::MAX, packet.get_checksum());
-        assert_eq!([0x0FF, 0xFF], packet.packet()[10..=11]);
+        packet.header.checksum = u16::MAX;
+        assert_eq!(u16::MAX, packet.header.checksum);
+        assert_eq!([0xFF, 0xFF], packet.packet()[10..=11]);
     }
 
     #[test]
     fn test_source() {
         let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
         let mut packet = Ipv4Packet::new(&mut buf).unwrap();
-        packet.set_source(Ipv4Addr::LOCALHOST);
-        assert_eq!(Ipv4Addr::LOCALHOST, packet.get_source());
-        assert_eq!([0x07F, 0x00, 0x00, 0x01], packet.packet()[12..=15]);
-        packet.set_source(Ipv4Addr::UNSPECIFIED);
-        assert_eq!(Ipv4Addr::UNSPECIFIED, packet.get_source());
+        packet.header.source = Ipv4Addr::LOCALHOST.octets();
+        assert_eq!(Ipv4Addr::LOCALHOST, Ipv4Addr::from(packet.header.source));
+        assert_eq!([0x7F, 0x00, 0x00, 0x01], packet.packet()[12..=15]);
+        packet.header.source = Ipv4Addr::UNSPECIFIED.octets();
+        assert_eq!(Ipv4Addr::UNSPECIFIED, Ipv4Addr::from(packet.header.source));
         assert_eq!([0x00, 0x00, 0x00, 0x00], packet.packet()[12..=15]);
-        packet.set_source(Ipv4Addr::BROADCAST);
-        assert_eq!(Ipv4Addr::BROADCAST, packet.get_source());
+        packet.header.source = Ipv4Addr::BROADCAST.octets();
+        assert_eq!(Ipv4Addr::BROADCAST, Ipv4Addr::from(packet.header.source));
         assert_eq!([0xFF, 0xFF, 0xFF, 0xFF], packet.packet()[12..=15]);
-        packet.set_source(Ipv4Addr::new(0xDE, 0x9A, 0x56, 0x12));
-        assert_eq!(Ipv4Addr::new(0xDE, 0x9A, 0x56, 0x12), packet.get_source());
+        packet.header.source = Ipv4Addr::new(0xDE, 0x9A, 0x56, 0x12).octets();
+        assert_eq!(Ipv4Addr::new(0xDE, 0x9A, 0x56, 0x12), Ipv4Addr::from(packet.header.source));
         assert_eq!([0xDE, 0x9A, 0x56, 0x12], packet.packet()[12..=15]);
     }
 
@@ -417,20 +306,17 @@ mod tests {
     fn test_destination() {
         let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
         let mut packet = Ipv4Packet::new(&mut buf).unwrap();
-        packet.set_destination(Ipv4Addr::LOCALHOST);
-        assert_eq!(Ipv4Addr::LOCALHOST, packet.get_destination());
-        assert_eq!([0x07F, 0x00, 0x00, 0x01], packet.packet()[16..=19]);
-        packet.set_destination(Ipv4Addr::UNSPECIFIED);
-        assert_eq!(Ipv4Addr::UNSPECIFIED, packet.get_destination());
+        packet.header.destination = Ipv4Addr::LOCALHOST.octets();
+        assert_eq!(Ipv4Addr::LOCALHOST, Ipv4Addr::from(packet.header.destination));
+        assert_eq!([0x7F, 0x00, 0x00, 0x01], packet.packet()[16..=19]);
+        packet.header.destination = Ipv4Addr::UNSPECIFIED.octets();
+        assert_eq!(Ipv4Addr::UNSPECIFIED, Ipv4Addr::from(packet.header.destination));
         assert_eq!([0x00, 0x00, 0x00, 0x00], packet.packet()[16..=19]);
-        packet.set_destination(Ipv4Addr::BROADCAST);
-        assert_eq!(Ipv4Addr::BROADCAST, packet.get_destination());
+        packet.header.destination = Ipv4Addr::BROADCAST.octets();
+        assert_eq!(Ipv4Addr::BROADCAST, Ipv4Addr::from(packet.header.destination));
         assert_eq!([0xFF, 0xFF, 0xFF, 0xFF], packet.packet()[16..=19]);
-        packet.set_destination(Ipv4Addr::new(0xDE, 0x9A, 0x56, 0x12));
-        assert_eq!(
-            Ipv4Addr::new(0xDE, 0x9A, 0x56, 0x12),
-            packet.get_destination()
-        );
+        packet.header.destination = Ipv4Addr::new(0xDE, 0x9A, 0x56, 0x12).octets();
+        assert_eq!(Ipv4Addr::new(0xDE, 0x9A, 0x56, 0x12), Ipv4Addr::from(packet.header.destination));
         assert_eq!([0xDE, 0x9A, 0x56, 0x12], packet.packet()[16..=19]);
     }
 
@@ -441,21 +327,18 @@ mod tests {
             0x00, 0x01, 0xde, 0x9a, 0x56, 0x12,
         ];
         let packet = Ipv4Packet::new_view(&buf).unwrap();
-        assert_eq!(4, packet.get_version());
-        assert_eq!(5, packet.get_header_length());
-        assert_eq!(0, packet.get_dscp());
-        assert_eq!(0, packet.get_ecn());
-        assert_eq!(84, packet.get_total_length());
-        assert_eq!(41585, packet.get_identification());
-        assert_eq!(0, packet.get_flags_and_fragment_offset());
-        assert_eq!(21, packet.get_ttl());
-        assert_eq!(IpProtocol::Udp, packet.get_protocol());
-        assert_eq!(39662, packet.get_checksum());
-        assert_eq!(Ipv4Addr::new(0x07F, 0x00, 0x00, 0x01), packet.get_source());
-        assert_eq!(
-            Ipv4Addr::new(0xde, 0x9a, 0x56, 0x12),
-            packet.get_destination()
-        );
+        assert_eq!(4, (packet.header.version_ihl & 0xf0) >> 4);
+        assert_eq!(5, packet.header.version_ihl & 0xf);
+        assert_eq!(0, (packet.header.dscp_ecn & 0xfc) >> 2);
+        assert_eq!(0, packet.header.dscp_ecn & 0x3);
+        assert_eq!(84, packet.header.total_length);
+        assert_eq!(41585, packet.header.identification);
+        assert_eq!(0, packet.header.flags_fragment_offset);
+        assert_eq!(21, packet.header.ttl);
+        assert_eq!(IpProtocol::Udp, IpProtocol::from(packet.header.protocol));
+        assert_eq!(39662, packet.header.checksum);
+        assert_eq!(Ipv4Addr::new(0x7F, 0x00, 0x00, 0x01), Ipv4Addr::from(packet.header.source));
+        assert_eq!(Ipv4Addr::new(0xde, 0x9a, 0x56, 0x12), Ipv4Addr::from(packet.header.destination));
         assert!(packet.payload().is_empty());
     }
 

--- a/crates/trippy-packet/src/udp.rs
+++ b/crates/trippy-packet/src/udp.rs
@@ -1,27 +1,27 @@
-use crate::buffer::Buffer;
 use crate::error::{Error, Result};
-use crate::fmt_payload;
+use bytemuck::{Pod, Zeroable};
 use std::fmt::{Debug, Formatter};
 
-const SOURCE_PORT_OFFSET: usize = 0;
-const DESTINATION_PORT_OFFSET: usize = 2;
-const LENGTH_OFFSET: usize = 4;
-const CHECKSUM_OFFSET: usize = 6;
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, Zeroable)]
+pub struct UdpHeader {
+    pub source_port: u16,
+    pub destination_port: u16,
+    pub length: u16,
+    pub checksum: u16,
+}
 
-/// Represents a UDP Packet.
-///
-/// The internal representation is held in network byte order (big-endian) and all accessor methods
-/// take and return data in host byte order, converting as necessary for the given architecture.
 pub struct UdpPacket<'a> {
-    buf: Buffer<'a>,
+    header: &'a mut UdpHeader,
+    payload: &'a mut [u8],
 }
 
 impl<'a> UdpPacket<'a> {
-    pub fn new(packet: &mut [u8]) -> Result<UdpPacket<'_>> {
+    pub fn new(packet: &'a mut [u8]) -> Result<UdpPacket<'a>> {
         if packet.len() >= UdpPacket::minimum_packet_size() {
-            Ok(UdpPacket {
-                buf: Buffer::Mutable(packet),
-            })
+            let (header_bytes, payload) = packet.split_at_mut(std::mem::size_of::<UdpHeader>());
+            let header = bytemuck::from_bytes_mut(header_bytes);
+            Ok(UdpPacket { header, payload })
         } else {
             Err(Error::InsufficientPacketBuffer(
                 String::from("UdpPacket"),
@@ -31,11 +31,11 @@ impl<'a> UdpPacket<'a> {
         }
     }
 
-    pub fn new_view(packet: &[u8]) -> Result<UdpPacket<'_>> {
+    pub fn new_view(packet: &'a [u8]) -> Result<UdpPacket<'a>> {
         if packet.len() >= UdpPacket::minimum_packet_size() {
-            Ok(UdpPacket {
-                buf: Buffer::Immutable(packet),
-            })
+            let (header_bytes, payload) = packet.split_at(std::mem::size_of::<UdpHeader>());
+            let header = bytemuck::from_bytes_mut(header_bytes);
+            Ok(UdpPacket { header, payload })
         } else {
             Err(Error::InsufficientPacketBuffer(
                 String::from("UdpPacket"),
@@ -47,71 +47,21 @@ impl<'a> UdpPacket<'a> {
 
     #[must_use]
     pub const fn minimum_packet_size() -> usize {
-        8
-    }
-
-    #[must_use]
-    pub fn get_source(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes(SOURCE_PORT_OFFSET))
-    }
-
-    #[must_use]
-    pub fn get_destination(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes(DESTINATION_PORT_OFFSET))
-    }
-
-    #[must_use]
-    pub fn get_length(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes(LENGTH_OFFSET))
-    }
-
-    #[must_use]
-    pub fn get_checksum(&self) -> u16 {
-        u16::from_be_bytes(self.buf.get_bytes(CHECKSUM_OFFSET))
-    }
-
-    pub fn set_source(&mut self, val: u16) {
-        self.buf.set_bytes(SOURCE_PORT_OFFSET, val.to_be_bytes());
-    }
-
-    pub fn set_destination(&mut self, val: u16) {
-        self.buf
-            .set_bytes(DESTINATION_PORT_OFFSET, val.to_be_bytes());
-    }
-
-    pub fn set_length(&mut self, val: u16) {
-        self.buf.set_bytes(LENGTH_OFFSET, val.to_be_bytes());
-    }
-
-    pub fn set_checksum(&mut self, val: u16) {
-        self.buf.set_bytes(CHECKSUM_OFFSET, val.to_be_bytes());
+        std::mem::size_of::<UdpHeader>()
     }
 
     pub fn set_payload(&mut self, vals: &[u8]) {
-        let current_offset = Self::minimum_packet_size();
-        self.buf.as_slice_mut()[current_offset..current_offset + vals.len()].copy_from_slice(vals);
+        self.payload.copy_from_slice(vals);
     }
 
     #[must_use]
     pub fn packet(&self) -> &[u8] {
-        self.buf.as_slice()
+        unsafe { std::slice::from_raw_parts(self.header as *const _ as *const u8, self.payload.len() + std::mem::size_of::<UdpHeader>()) }
     }
 
     #[must_use]
     pub fn payload(&self) -> &[u8] {
-        &self.buf.as_slice()[Self::minimum_packet_size()..]
-    }
-}
-
-impl Debug for UdpPacket<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("UdpPacket")
-            .field("source", &self.get_source())
-            .field("destination", &self.get_destination())
-            .field("length", &self.get_length())
-            .field("checksum", &self.get_checksum())
-            .field("payload", &fmt_payload(self.payload()))
-            .finish()
+        self.payload
     }
 }
 
@@ -123,17 +73,17 @@ mod tests {
     fn test_source() {
         let mut buf = [0_u8; UdpPacket::minimum_packet_size()];
         let mut packet = UdpPacket::new(&mut buf).unwrap();
-        packet.set_source(0);
-        assert_eq!(0, packet.get_source());
+        packet.header.source_port = 0;
+        assert_eq!(0, packet.header.source_port);
         assert_eq!([0x00, 0x00], packet.packet()[..=1]);
-        packet.set_source(80);
-        assert_eq!(80, packet.get_source());
+        packet.header.source_port = 80;
+        assert_eq!(80, packet.header.source_port);
         assert_eq!([0x00, 0x50], packet.packet()[..=1]);
-        packet.set_source(443);
-        assert_eq!(443, packet.get_source());
+        packet.header.source_port = 443;
+        assert_eq!(443, packet.header.source_port);
         assert_eq!([0x01, 0xBB], packet.packet()[..=1]);
-        packet.set_source(u16::MAX);
-        assert_eq!(u16::MAX, packet.get_source());
+        packet.header.source_port = u16::MAX;
+        assert_eq!(u16::MAX, packet.header.source_port);
         assert_eq!([0xFF, 0xFF], packet.packet()[..=1]);
     }
 
@@ -141,17 +91,17 @@ mod tests {
     fn test_destination() {
         let mut buf = [0_u8; UdpPacket::minimum_packet_size()];
         let mut packet = UdpPacket::new(&mut buf).unwrap();
-        packet.set_destination(0);
-        assert_eq!(0, packet.get_destination());
+        packet.header.destination_port = 0;
+        assert_eq!(0, packet.header.destination_port);
         assert_eq!([0x00, 0x00], packet.packet()[2..=3]);
-        packet.set_destination(80);
-        assert_eq!(80, packet.get_destination());
+        packet.header.destination_port = 80;
+        assert_eq!(80, packet.header.destination_port);
         assert_eq!([0x00, 0x50], packet.packet()[2..=3]);
-        packet.set_destination(443);
-        assert_eq!(443, packet.get_destination());
+        packet.header.destination_port = 443;
+        assert_eq!(443, packet.header.destination_port);
         assert_eq!([0x01, 0xBB], packet.packet()[2..=3]);
-        packet.set_destination(u16::MAX);
-        assert_eq!(u16::MAX, packet.get_destination());
+        packet.header.destination_port = u16::MAX;
+        assert_eq!(u16::MAX, packet.header.destination_port);
         assert_eq!([0xFF, 0xFF], packet.packet()[2..=3]);
     }
 
@@ -159,17 +109,17 @@ mod tests {
     fn test_length() {
         let mut buf = [0_u8; UdpPacket::minimum_packet_size()];
         let mut packet = UdpPacket::new(&mut buf).unwrap();
-        packet.set_length(0);
-        assert_eq!(0, packet.get_length());
+        packet.header.length = 0;
+        assert_eq!(0, packet.header.length);
         assert_eq!([0x00, 0x00], packet.packet()[4..=5]);
-        packet.set_length(202);
-        assert_eq!(202, packet.get_length());
+        packet.header.length = 202;
+        assert_eq!(202, packet.header.length);
         assert_eq!([0x00, 0xCA], packet.packet()[4..=5]);
-        packet.set_length(1025);
-        assert_eq!(1025, packet.get_length());
+        packet.header.length = 1025;
+        assert_eq!(1025, packet.header.length);
         assert_eq!([0x04, 0x01], packet.packet()[4..=5]);
-        packet.set_length(u16::MAX);
-        assert_eq!(u16::MAX, packet.get_length());
+        packet.header.length = u16::MAX;
+        assert_eq!(u16::MAX, packet.header.length);
         assert_eq!([0xFF, 0xFF], packet.packet()[4..=5]);
     }
 
@@ -177,17 +127,17 @@ mod tests {
     fn test_checksum() {
         let mut buf = [0_u8; UdpPacket::minimum_packet_size()];
         let mut packet = UdpPacket::new(&mut buf).unwrap();
-        packet.set_checksum(0);
-        assert_eq!(0, packet.get_checksum());
+        packet.header.checksum = 0;
+        assert_eq!(0, packet.header.checksum);
         assert_eq!([0x00, 0x00], packet.packet()[6..=7]);
-        packet.set_checksum(202);
-        assert_eq!(202, packet.get_checksum());
+        packet.header.checksum = 202;
+        assert_eq!(202, packet.header.checksum);
         assert_eq!([0x00, 0xCA], packet.packet()[6..=7]);
-        packet.set_checksum(1025);
-        assert_eq!(1025, packet.get_checksum());
+        packet.header.checksum = 1025;
+        assert_eq!(1025, packet.header.checksum);
         assert_eq!([0x04, 0x01], packet.packet()[6..=7]);
-        packet.set_checksum(u16::MAX);
-        assert_eq!(u16::MAX, packet.get_checksum());
+        packet.header.checksum = u16::MAX;
+        assert_eq!(u16::MAX, packet.header.checksum);
         assert_eq!([0xFF, 0xFF], packet.packet()[6..=7]);
     }
 
@@ -195,10 +145,10 @@ mod tests {
     fn test_view() {
         let buf = [0x68, 0xbf, 0x81, 0xb6, 0x00, 0x40, 0xac, 0xbe];
         let packet = UdpPacket::new_view(&buf).unwrap();
-        assert_eq!(26815, packet.get_source());
-        assert_eq!(33206, packet.get_destination());
-        assert_eq!(64, packet.get_length());
-        assert_eq!(44222, packet.get_checksum());
+        assert_eq!(26815, packet.header.source_port);
+        assert_eq!(33206, packet.header.destination_port);
+        assert_eq!(64, packet.header.length);
+        assert_eq!(44222, packet.header.checksum);
         assert!(packet.payload().is_empty());
     }
 


### PR DESCRIPTION
Reimplement `UdpPacket` and `Ipv4Packet` structs using zero copy with the bytemuck crate, with real fields for things like src port, and all getters and setters removed.

* Add `bytemuck` as a dependency in `crates/trippy-packet/Cargo.toml`.
* Modify `crates/trippy-packet/src/buffer.rs` to use bytemuck for zero copy and add tests for Pod struct.
* Modify `crates/trippy-packet/src/icmp_extension.rs` to add assertions for extension object length.
* Modify `crates/trippy-packet/src/icmpv4.rs` to use bytemuck for zero copy and remove getter and setter methods.
* Reimplement `UdpPacket` struct in `crates/trippy-packet/src/udp.rs` using zero copy with the bytemuck crate.
  - Replace getter and setter methods with real fields for `source_port`, `destination_port`, `length`, and `checksum`.
  - Remove all getter and setter methods.
  - Update methods to access the fields of the struct directly.
* Reimplement `Ipv4Packet` struct in `crates/trippy-packet/src/ipv4.rs` using zero copy with the bytemuck crate.
  - Replace getter and setter methods with real fields for `version_ihl`, `dscp_ecn`, `total_length`, `identification`, `flags_fragment_offset`, `ttl`, `protocol`, `checksum`, `source`, and `destination`.
  - Remove all getter and setter methods.
  - Update methods to access the fields of the struct directly.

