### PR TITLE
fix: rename IP to Ip

### DIFF
--- a/crates/trippy-tui/src/config.rs
+++ b/crates/trippy-tui/src/config.rs
@@ -127,7 +127,7 @@ impl From<MultipathStrategy> for MultipathStrategyConfig {
 #[serde(rename_all = "kebab-case")]
 pub enum AddressMode {
     /// Show IP address only.
-    IP,
+    Ip,
     /// Show reverse-lookup DNS hostname only.
     Host,
     /// Show both IP address and reverse-lookup DNS hostname.
@@ -1476,7 +1476,7 @@ mod tests {
     }
 
     #[test_case("trip example.com", Ok(cfg().tui_address_mode(AddressMode::Host).build()); "default tui address mode")]
-    #[test_case("trip example.com --tui-address-mode ip", Ok(cfg().tui_address_mode(AddressMode::IP).build()); "ip tui address mode")]
+    #[test_case("trip example.com --tui-address-mode ip", Ok(cfg().tui_address_mode(AddressMode::Ip).build()); "ip tui address mode")]
     #[test_case("trip example.com --tui-address-mode host", Ok(cfg().tui_address_mode(AddressMode::Host).build()); "host tui address mode")]
     #[test_case("trip example.com --tui-address-mode both", Ok(cfg().tui_address_mode(AddressMode::Both).build()); "both tui address mode")]
     #[test_case("trip example.com -a both", Ok(cfg().tui_address_mode(AddressMode::Both).build()); "custom tui address mode short")]

--- a/crates/trippy-tui/src/frontend.rs
+++ b/crates/trippy-tui/src/frontend.rs
@@ -182,7 +182,7 @@ fn run_app<B: Backend>(
                     } else if bindings.previous_hop_address.check(key) {
                         app.previous_hop_address();
                     } else if bindings.address_mode_ip.check(key) {
-                        app.tui_config.address_mode = AddressMode::IP;
+                        app.tui_config.address_mode = AddressMode::Ip;
                     } else if bindings.address_mode_host.check(key) {
                         app.tui_config.address_mode = AddressMode::Host;
                     } else if bindings.address_mode_both.check(key) {

--- a/crates/trippy-tui/src/frontend/render/settings.rs
+++ b/crates/trippy-tui/src/frontend/render/settings.rs
@@ -591,7 +591,7 @@ fn format_as_mode(as_mode: AsMode) -> String {
 /// Format the `AddressMode`.
 fn format_address_mode(address_mode: AddressMode) -> String {
     match address_mode {
-        AddressMode::IP => "ip".to_string(),
+        AddressMode::Ip => "ip".to_string(),
         AddressMode::Host => "host".to_string(),
         AddressMode::Both => "both".to_string(),
     }

--- a/crates/trippy-tui/src/frontend/render/table.rs
+++ b/crates/trippy-tui/src/frontend/render/table.rs
@@ -307,7 +307,7 @@ fn format_address(
     config: &TuiConfig,
 ) -> String {
     let addr_fmt = match config.address_mode {
-        AddressMode::IP => addr.to_string(),
+        AddressMode::Ip => addr.to_string(),
         AddressMode::Host => {
             if config.lookup_as_info {
                 let entry = dns.lazy_reverse_lookup_with_asinfo(*addr);


### PR DESCRIPTION
Needed because kebab-case for `IP` is `i-p` but example toml file shows `ip`
so renamed to `Ip` so that kebab version is `ip`

Closes #1327 