### PR TITLE
WIP: refactor(core): remove custom `ErrorKind`

### DIFF
--- a/crates/trippy-core/src/error.rs
+++ b/crates/trippy-core/src/error.rs
@@ -67,9 +67,8 @@ impl IoError {
 /// This includes additional error kinds that are not part of the standard [`io::ErrorKind`].
 #[derive(Debug, Eq, PartialEq)]
 pub enum ErrorKind {
+    // TODO: awaiting https://github.com/rust-lang/rust/issues/130840
     InProgress,
-    HostUnreachable,
-    NetUnreachable,
     Std(io::ErrorKind),
 }
 

--- a/crates/trippy-core/src/net/common.rs
+++ b/crates/trippy-core/src/net/common.rs
@@ -11,7 +11,7 @@ impl ErrorMapper {
         match err {
             Error::IoError(io_err) => match io_err.kind() {
                 ErrorKind::InProgress => Ok(()),
-                _ => Err(Error::IoError(io_err)),
+                ErrorKind::Std(_) => Err(Error::IoError(io_err)),
             },
             err => Err(err),
         }
@@ -80,9 +80,10 @@ mod tests {
 
     #[test]
     fn test_probe_failed() {
-        let io_err = io::Error::from(ErrorKind::HostUnreachable);
+        let io_err = io::Error::from(ErrorKind::Std(io::ErrorKind::HostUnreachable));
         let err = Error::IoError(IoError::Bind(io_err, ADDR));
-        let probe_err = ErrorMapper::probe_failed(err, ErrorKind::HostUnreachable);
+        let probe_err =
+            ErrorMapper::probe_failed(err, ErrorKind::Std(io::ErrorKind::HostUnreachable));
         assert!(matches!(probe_err, Error::ProbeFailed(_)));
     }
 }

--- a/crates/trippy-core/src/net/ipv4.rs
+++ b/crates/trippy-core/src/net/ipv4.rs
@@ -111,8 +111,8 @@ impl Ipv4 {
         icmp_send_socket
             .send_to(ipv4.packet(), remote_addr)
             .map_err(Error::IoError)
-            .map_err(|err| ErrorMapper::probe_failed(err, ErrorKind::HostUnreachable))
-            .map_err(|err| ErrorMapper::probe_failed(err, ErrorKind::NetUnreachable))
+            .map_err(|err| ErrorMapper::probe_failed(err, HOST_UNREACHABLE_KIND))
+            .map_err(|err| ErrorMapper::probe_failed(err, NETWORK_UNREACHABLE_KIND))
             .map_err(|err| ErrorMapper::probe_failed(err, INVALID_INPUT_KIND))?;
         Ok(())
     }
@@ -176,8 +176,8 @@ impl Ipv4 {
         raw_send_socket
             .send_to(ipv4.packet(), remote_addr)
             .map_err(Error::IoError)
-            .map_err(|err| ErrorMapper::probe_failed(err, ErrorKind::HostUnreachable))
-            .map_err(|err| ErrorMapper::probe_failed(err, ErrorKind::NetUnreachable))?;
+            .map_err(|err| ErrorMapper::probe_failed(err, HOST_UNREACHABLE_KIND))
+            .map_err(|err| ErrorMapper::probe_failed(err, NETWORK_UNREACHABLE_KIND))?;
         Ok(())
     }
 
@@ -217,7 +217,7 @@ impl Ipv4 {
             .map_err(Error::IoError)
             .or_else(ErrorMapper::in_progress)
             .map_err(|err| ErrorMapper::addr_in_use(err, remote_addr))
-            .map_err(|err| ErrorMapper::probe_failed(err, ErrorKind::NetUnreachable))?;
+            .map_err(|err| ErrorMapper::probe_failed(err, NETWORK_UNREACHABLE_KIND))?;
         Ok(socket)
     }
 
@@ -477,6 +477,8 @@ impl Ipv4 {
 
 const ADDR_NOT_AVAILABLE_KIND: ErrorKind = ErrorKind::Std(io::ErrorKind::AddrNotAvailable);
 const INVALID_INPUT_KIND: ErrorKind = ErrorKind::Std(io::ErrorKind::InvalidInput);
+const HOST_UNREACHABLE_KIND: ErrorKind = ErrorKind::Std(io::ErrorKind::HostUnreachable);
+const NETWORK_UNREACHABLE_KIND: ErrorKind = ErrorKind::Std(io::ErrorKind::NetworkUnreachable);
 
 const fn icmp_payload_size(packet_size: usize) -> usize {
     let ip_header_size = Ipv4Packet::minimum_packet_size();

--- a/crates/trippy-core/src/net/platform/unix.rs
+++ b/crates/trippy-core/src/net/platform/unix.rs
@@ -491,10 +491,6 @@ mod socket {
         fn from(value: &io::Error) -> Self {
             if value.raw_os_error() == io::Error::from(Error::EINPROGRESS).raw_os_error() {
                 Self::InProgress
-            } else if value.raw_os_error() == io::Error::from(Error::EHOSTUNREACH).raw_os_error() {
-                Self::HostUnreachable
-            } else if value.raw_os_error() == io::Error::from(Error::ENETUNREACH).raw_os_error() {
-                Self::NetUnreachable
             } else {
                 Self::Std(value.kind())
             }
@@ -506,8 +502,6 @@ mod socket {
         fn from(value: ErrorKind) -> Self {
             match value {
                 ErrorKind::InProgress => Self::from(Error::EINPROGRESS),
-                ErrorKind::HostUnreachable => Self::from(Error::EHOSTUNREACH),
-                ErrorKind::NetUnreachable => Self::from(Error::ENETUNREACH),
                 ErrorKind::Std(kind) => Self::from(kind),
             }
         }


### PR DESCRIPTION
Rust 1.83 stabilised `HostUnreachable` and `NetworkUnreachable` (but not on Windows):

https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html#variant.HostUnreachable
https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html#variant.NetworkUnreachable

However, `InProgress` is still unstable:

https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.InProgress

Once the latter is stable, we ca remove the custom `ErrorKind` type.