### PR TITLE
fix(tui): sample history and frequency charts ignore sub-millisecond samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `--tui-preserve-screen` ([#1375](https://github.com/fujiapple852/trippy/issues/1375))
 - Config item `tui-address-mode` does not accept `ip` ([#1327](https://github.com/fujiapple852/trippy/issues/1327))
 - Icmp extension mode not shown in Tui settings ([#1289](https://github.com/fujiapple852/trippy/issues/1289))
+- Sample history and frequency charts ignore sub-millisecond
+  samples ([#1398](https://github.com/fujiapple852/trippy/issues/1398))
 
 ## [0.11.0] - 2024-08-11
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -319,6 +319,9 @@ The previous release of Trippy introduced a bug ([#1290](https://github.com/fuji
 caused reverse DNS lookups to be enqueued multiple times when the `dns-ttl` expired, potentially leading to the hostname
 being displayed as `Timeout: xxx` for a brief period.
 
+A long standing bug ([#1398](https://github.com/fujiapple852/trippy/issues/1398)) which caused the TUI sample history
+and frequency charts to ignore sub-millisecond samples has been fixed.
+
 This release fixes a bug ([#1287](https://github.com/fujiapple852/trippy/issues/1287)) that caused a tracer panic when
 parsing certain ICMP extensions with malformed lengths.
 

--- a/crates/trippy-tui/src/frontend/render/histogram.rs
+++ b/crates/trippy-tui/src/frontend/render/histogram.rs
@@ -43,7 +43,7 @@ fn sample_frequency(samples: &[Duration]) -> Vec<(String, u64)> {
     let sample_count = samples.len();
     let mut count_by_duration: BTreeMap<u128, u64> = BTreeMap::new();
     for sample in samples {
-        if sample.as_millis() > 0 {
+        if !sample.is_zero() {
             *count_by_duration.entry(sample.as_millis()).or_default() += 1;
         }
     }

--- a/crates/trippy-tui/src/frontend/render/history.rs
+++ b/crates/trippy-tui/src/frontend/render/history.rs
@@ -13,10 +13,10 @@ pub fn render(f: &mut Frame<'_>, app: &TuiApp, rect: Rect) {
         .iter()
         .take(rect.width as usize)
         .map(|s| {
-            if s.as_secs_f64() > 0_f64 {
-                Some((s.as_secs_f64() * 1000_f64) as u64)
-            } else {
+            if s.is_zero() {
                 None
+            } else {
+                Some(s.as_micros() as u64)
             }
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
Closes #1398 