### PR TITLE
Add CI job to enforce conventional commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,3 +222,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dprint/check@v2.2
+
+  conventional-commits:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Conventional Commits Lint
+        uses: webiny/action-conventional-commits@v1.3.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          allowed-commit-types: "feat,fix,chore,docs,style,refactor,test,build,ci,revert"


### PR DESCRIPTION
Add a CI job to enforce conventional commits.

* Add a new job `conventional-commits` to `.github/workflows/ci.yml` to enforce conventional commits using `webiny/action-conventional-commits@v1`.
* Configure the job to run on every pull requests to the `master` branch.
* Define the conventional commit types: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `test`, `build`, and `ci`.
