### PR TITLE
Revert "chore: disable dependabot for npm ecosystem"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,13 +21,3 @@ updates:
       - dependency-type: "direct"
     open-pull-requests-limit: 10
     rebase-strategy: "disabled"
-
-  # NPM dependencies (docs) - ignore all
-  - package-ecosystem: "npm"
-    directory: "/docs"
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "all"


### PR DESCRIPTION
This reverts commit 56d2ff744daa2f5f50689bfeb8711a2643b9874a.