### PR TITLE
chore: allow unmaintained `paste` crate

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,3 +8,7 @@ exceptions = []
 version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
+ignore = [
+  # allow unmaintained paste crate
+  { id = "RUSTSEC-2024-0436" },
+]


### PR DESCRIPTION
see https://rustsec.org/advisories/RUSTSEC-2024-0436