### PR TITLE
build: exclude examples from default cargo builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,15 @@ members = [
   "examples/*",
 ]
 
+default-members = [
+  "crates/trippy",
+  "crates/trippy-tui",
+  "crates/trippy-core",
+  "crates/trippy-packet",
+  "crates/trippy-privilege",
+  "crates/trippy-dns",
+]
+
 [workspace.package]
 version = "0.13.0-dev"
 authors = ["FujiApple <fujiapple852@gmail.com>"]


### PR DESCRIPTION
I noticed that the hello-world and traceroute example binaries were being built by default in my nix-darwin system. This caused my system traceroute binary to be overridden by the example version.

This PR ensures these examples are only built when explicitly requested, preventing them from interfering with system binaries. If this is the intended behavior feel free to close this and I will try to solve this in nixpkgs instead.