### PR TITLE
Fix tracer comment grammar

### DIFF
--- a/crates/trippy-core/tests/sim/tracer.rs
+++ b/crates/trippy-core/tests/sim/tracer.rs
@@ -12,7 +12,7 @@ use trippy_core::{
 
 // The length of time to wait after the completion of the tracing before
 // cancelling the network simulator.  This is needed to ensure that all
-// in-flight packets for the current test are send ot received prior to
+// in-flight packets for the current test are sent or received prior to
 // ending the round so that they are not incorrectly used in a subsequent
 // test.
 const CLEANUP_DELAY: Duration = Duration::from_millis(1000);


### PR DESCRIPTION
## Summary
- correct grammar of cleanup comment in tracer tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683f99522314832999bbcac147c7023e