### PR TITLE
fix(tui): use correct max value for y-axis chart scale

### DIFF
--- a/crates/trippy-tui/src/frontend/render/chart.rs
+++ b/crates/trippy-tui/src/frontend/render/chart.rs
@@ -28,7 +28,7 @@ pub fn render(f: &mut Frame<'_>, app: &TuiApp, rect: Rect) {
         .iter()
         .flatten()
         .map(|&(_, s)| s)
-        .max_by_key(|&c| c as u64)
+        .max_by_key(|&c| (c * 1000.0) as u64)
         .unwrap_or_default();
     let sets = series_data
         .iter()


### PR DESCRIPTION
Previously the `max_sample` value for the y-axis scale was determined ignoring decimals.

This PR increases precision of `max_by_key` to nanoseconds by multiplying with 1000 before casting to integer to fix the y-axis scale.

Fixes #1677

Screencast:

https://github.com/user-attachments/assets/2fa78d12-8c63-446e-8578-531eb6a051cc

