### PR TITLE
Add colors to --help/-h

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-cargo"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d546f0e84ff2bfa4da1ce9b54be42285767ba39c688572ca32412a09a73851e5"
+dependencies = [
+ "anstyle",
+ "clap",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2402,6 +2412,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
+ "clap-cargo",
  "clap_complete",
  "clap_mangen",
  "comfy-table",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ caps = "0.5.6"
 chrono = { version = "0.4.42", default-features = false }
 chrono-tz = "0.10.4"
 clap = { version = "4.5.20", default-features = false }
+clap-cargo = "0.15.2"
 clap_complete = "4.4.9"
 clap_mangen = "0.2.20"
 comfy-table = { version = "7.1.4", default-features = false }

--- a/crates/trippy-tui/Cargo.toml
+++ b/crates/trippy-tui/Cargo.toml
@@ -44,6 +44,7 @@ tracing-subscriber = { workspace = true, default-features = false, features = ["
 tracing.workspace = true
 unic-langid.workspace = true
 unicode-width.workspace = true
+clap-cargo.workspace = true
 
 [dev-dependencies]
 insta = { workspace = true, features = ["serde"] }

--- a/crates/trippy-tui/src/config/cmd.rs
+++ b/crates/trippy-tui/src/config/cmd.rs
@@ -6,7 +6,6 @@ use crate::config::{
     TuiKeyBinding,
 };
 use anyhow::anyhow;
-use clap::builder::Styles;
 use clap::Parser;
 use clap_complete::Shell;
 use std::net::IpAddr;
@@ -16,7 +15,7 @@ use std::time::Duration;
 /// Trace a route to a host and record statistics
 #[expect(clippy::doc_markdown)]
 #[derive(Parser, Debug)]
-#[command(name = "trip", author, version, about, long_about = None, arg_required_else_help(true), styles=Styles::styled())]
+#[command(name = "trip", author, version, about, long_about = None, arg_required_else_help(true), styles=clap_cargo::style::CLAP_STYLING)]
 pub struct Args {
     /// A space delimited list of hostnames and IPs to trace
     #[arg(required_unless_present_any(["print_tui_theme_items", "print_tui_binding_commands", "print_config_template", "generate", "generate_man", "print_locales"]))]


### PR DESCRIPTION
Closes #1688 

I used [clap-cargo](https://github.com/crate-ci/clap-cargo) as it's easy to use and provides sensible default styles.
User can disable colors via `NO_COLOR=1` environment variable

Output of `trip -h`:
| before | after | `NO_COLOR=1` |
| - | - | - |
| <img width="1808" height="1381" alt="trip-before" src="https://github.com/user-attachments/assets/97849670-0f80-4313-90c2-5f8bb86406ae" /> | <img width="1808" height="1381" alt="trip-colors" src="https://github.com/user-attachments/assets/f51cc358-f066-48c2-9bc8-042b2e99d9e4" /> | <img width="1808" height="1381" alt="trip-no-color" src="https://github.com/user-attachments/assets/dcb59731-bd0d-4e96-a107-d6c655a0475d" /> |