### PR TITLE
chore: fix locked verson of `dns-lookup` to use `socket2` version `0.…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
 dependencies = [
  "cfg-if",
  "libc",
- "socket2 0.6.0",
+ "socket2 0.6.1",
  "windows-sys 0.60.2",
 ]
 


### PR DESCRIPTION
…6.1`