### PR TITLE
tui: fix `hops-table-row-inactive-text-color` not used

### DIFF
--- a/crates/trippy-core/src/state.rs
+++ b/crates/trippy-core/src/state.rs
@@ -72,12 +72,6 @@ impl State {
         self.state[&flow_id].is_target(hop)
     }
 
-    /// Is a given `Hop` in the current round for a given flow?
-    #[must_use]
-    pub fn is_in_round(&self, hop: &Hop, flow_id: FlowId) -> bool {
-        self.state[&flow_id].is_in_round(hop)
-    }
-
     /// Return the target `Hop` for a given flow.
     #[must_use]
     pub fn target_hop(&self, flow_id: FlowId) -> &Hop {
@@ -509,10 +503,6 @@ impl FlowState {
 
     const fn is_target(&self, hop: &Hop) -> bool {
         self.highest_ttl_for_round == hop.ttl
-    }
-
-    const fn is_in_round(&self, hop: &Hop) -> bool {
-        hop.ttl <= self.highest_ttl_for_round
     }
 
     fn target_hop(&self) -> &Hop {

--- a/crates/trippy-tui/src/frontend/render/table.rs
+++ b/crates/trippy-tui/src/frontend/render/table.rs
@@ -101,7 +101,6 @@ fn render_table_row(
     custom_columns: &Columns,
 ) -> Row<'static> {
     let is_selected_hop = app.selected_hop().is_some_and(|h| h.ttl() == hop.ttl());
-    let is_in_round = app.tracer_data().is_in_round(hop, app.selected_flow);
     let (_, row_height) = if is_selected_hop && app.show_hop_details {
         render_hostname_with_details(app, hop, dns, geoip_lookup, config)
     } else {
@@ -121,7 +120,7 @@ fn render_table_row(
             )
         })
         .collect();
-    let row_color = if is_in_round {
+    let row_color = if is_selected_hop {
         config.theme.hops_table_row_active_text
     } else {
         config.theme.hops_table_row_inactive_text


### PR DESCRIPTION
Previously, the code checked for `is_in_round` (tbh, no idea what that means), which was always true, so the option `hops-table-row-inactive-text-color` has never been used. Replaced that check with `is_selected_hop`, but I am not sure if this is a good idea, as I don't understand what `is_in_round` means.

Also, that function wasn't used anywhere except for this one line, so I removed it as well