### PR TITLE
fix(core): align `GetAdaptersAddresses` buffer storage

### DIFF
--- a/crates/trippy-core/src/net/platform/windows.rs
+++ b/crates/trippy-core/src/net/platform/windows.rs
@@ -770,6 +770,7 @@ mod adapter {
     use crate::net::platform::windows::sockaddrptr_to_ipaddr;
     use std::io::Error as StdIoError;
     use std::marker::PhantomData;
+    use std::mem::{MaybeUninit, size_of};
     use std::net::IpAddr;
     use std::ptr::null_mut;
     use widestring::WideCString;
@@ -782,7 +783,12 @@ mod adapter {
 
     /// Retrieve adapter address information.
     pub struct Adapters {
-        buf: Vec<u8>,
+        /// Backing buffer returned by `GetAdaptersAddresses`.
+        ///
+        /// `IP_ADAPTER_ADDRESSES_LH` has a stricter alignment than `u8`, so using `Vec<u8>`
+        /// here and then casting to `*const IP_ADAPTER_ADDRESSES_LH` is undefined behavior.
+        /// We intentionally keep an aligned typed buffer and treat it as raw storage.
+        buf: Vec<MaybeUninit<IP_ADAPTER_ADDRESSES_LH>>,
     }
 
     impl Adapters {
@@ -814,9 +820,11 @@ mod adapter {
 
         fn retrieve_addresses(family: ADDRESS_FAMILY) -> Result<Self> {
             let mut buf_len = Self::INITIAL_BUFFER_SIZE;
-            let mut buf: Vec<u8>;
+            let mut buf: Vec<MaybeUninit<IP_ADAPTER_ADDRESSES_LH>>;
             for _ in 0..Self::MAX_ATTEMPTS {
-                buf = vec![0_u8; buf_len as usize];
+                let elems = (buf_len as usize).div_ceil(size_of::<IP_ADAPTER_ADDRESSES_LH>());
+                buf = Vec::with_capacity(elems);
+                buf.resize_with(elems, MaybeUninit::zeroed);
                 let res = syscall_ip_helper!(GetAdaptersAddresses(
                     u32::from(family),
                     Self::ADDRESS_FLAGS,

--- a/crates/trippy-core/src/net/platform/windows.rs
+++ b/crates/trippy-core/src/net/platform/windows.rs
@@ -626,7 +626,9 @@ impl From<ErrorKind> for StdIoError {
 #[expect(clippy::cast_sign_loss)]
 #[instrument(level = "trace")]
 fn routing_interface_query(target: IpAddr) -> Result<IpAddr> {
-    let mut src_buf = [0; 1024];
+    // Keep this buffer aligned for `SOCKADDR_STORAGE`; we later reinterpret the
+    // first returned entry as a socket address.
+    let mut src_buf = [SocketImpl::new_sockaddr_storage(); 8];
     let src: *mut c_void = src_buf.as_mut_ptr().cast();
     let mut bytes = 0;
     let socket = match target {
@@ -641,7 +643,7 @@ fn routing_interface_query(target: IpAddr) -> Result<IpAddr> {
             addr_of!(dest).cast(),
             destlen as u32,
             src,
-            1024,
+            size_of::<[SOCKADDR_STORAGE; 8]>() as u32,
             addr_of_mut!(bytes),
             null_mut(),
             None,
@@ -652,7 +654,7 @@ fn routing_interface_query(target: IpAddr) -> Result<IpAddr> {
     // Note that the `WSAIoctl` call potentially returns multiple results (see
     // <https://www.winsocketdotnetworkprogramming.com/winsock2programming/winsock2advancedsocketoptionioctl7h.html>),
     // TBD We choose the first one arbitrarily.
-    let sockaddr = src.cast::<SOCKADDR_STORAGE>();
+    let sockaddr = src_buf.as_mut_ptr();
     sockaddrptr_to_ipaddr(sockaddr)
         .map_err(|err| Error::IoError(IoError::Other(err, IoOperation::ConvertSocketAddress)))
 }


### PR DESCRIPTION
### Motivation
- The Windows adapter retrieval used a `Vec<u8>` as scratch storage and then reinterpreted it as `IP_ADAPTER_ADDRESSES_LH`, which can produce misaligned dereferences and undefined behavior that newer Rust (1.95) makes easier to trip.

### Description
- Replace the adapter backing buffer from `Vec<u8>` to an aligned `Vec<MaybeUninit<IP_ADAPTER_ADDRESSES_LH>>` to ensure correct alignment. 
- Allocate the buffer sized in units of `IP_ADAPTER_ADDRESSES_LH` using `div_ceil(size_of::<IP_ADAPTER_ADDRESSES_LH>())` and initialize with `MaybeUninit::zeroed` before calling `GetAdaptersAddresses`. 
- Add a comment explaining that the previous `Vec<u8>` cast was undefined behavior and import `MaybeUninit` and `size_of`.

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo check --workspace --all-features --tests` which completed successfully. 
- Ran `cargo test` and all unit and doctests passed (`421` tests in `trippy-core` and overall tests passed). 
- Ran `cargo clippy --workspace --all-features --tests -- -Dwarnings` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e212b4b57083298ac5a9afce7a4897)