### PR TITLE
fix(core): keep Windows `WSARecvFrom` flags alive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           - build: windows-stable
             os: windows-2022
             target: x86_64-pc-windows-msvc
-            rust: "1.94"
+            rust: stable
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/crates/trippy-core/src/net/platform/windows.rs
+++ b/crates/trippy-core/src/net/platform/windows.rs
@@ -96,6 +96,7 @@ pub struct SocketImpl {
     buf: Box<[u8]>,
     from: Box<SOCKADDR_STORAGE>,
     from_len: i32,
+    recv_flags: u32,
     bytes_read: u32,
 }
 
@@ -123,6 +124,7 @@ impl SocketImpl {
             buf,
             from,
             from_len,
+            recv_flags: 0,
             bytes_read: 0,
         })
     }
@@ -218,13 +220,14 @@ impl SocketImpl {
             len: MAX_PACKET_SIZE as u32,
             buf: self.buf.as_mut_ptr(),
         };
+        self.recv_flags = 0;
         syscall!(
             WSARecvFrom(
                 self.inner.as_raw_socket() as usize,
                 addr_of!(wbuf),
                 1,
                 null_mut(),
-                &mut 0,
+                addr_of_mut!(self.recv_flags),
                 addr_of_mut!(*self.from).cast(),
                 addr_of_mut!(self.from_len),
                 addr_of_mut!(*self.ol),


### PR DESCRIPTION
## Summary

- keep `WSARecvFrom`'s receive flags storage alive for the full overlapped receive operation
- reset the receive flags before posting each receive
- unpin Windows sim CI from Rust 1.94 so it runs on stable/Rust 1.95

Fixes #1793