### PR TITLE
ci: add .typos.toml config and fix 'thr' typo in CHANGELOG

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,30 @@
+# Configuration for `typos` (https://github.com/crate-ci/typos).
+#
+# The intent is to keep the scan narrowly scoped to code and prose written for
+# contributors, rather than translated user-facing strings, generated shell
+# completions, and protocol terms that look like typos to a generic English
+# dictionary.
+
+[files]
+# Translated UI strings live here; they are maintained by translators and any
+# corrections should go through the i18n workflow, not the typo scanner.
+#
+# Generated shell-completion snapshots are written verbatim by the test suite
+# and should not be modified by hand.
+extend-exclude = [
+    "crates/trippy-tui/locales.toml",
+    "crates/trippy-tui/tests/resources/snapshots/*elvish*.snap",
+]
+
+[default.extend-identifiers]
+# Crate name — not a misspelling of "ratatouille".
+ratatui = "ratatui"
+
+[default.extend-words]
+# IP ECN values from RFC 3168 (and the NotECT / Not-ECT spelling used in the
+# codebase and tests). `typos` would otherwise try to rewrite these.
+ECT = "ECT"
+NotECT = "NotECT"
+# Hex byte that appears in hex_literal!() packet-dump fixtures; `typos`
+# otherwise reports it as "by"/"be".
+ba = "ba"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -414,7 +414,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Tui ([#72](https://github.com/fujiapple852/trippy/issues/72))
 - Added ability to enable and disable the `AS` lookup from the
   Tui ([#126](https://github.com/fujiapple852/trippy/issues/126))
-- Added ability to switch between hop address display modes (ip, hostname or both) in thr
+- Added ability to switch between hop address display modes (ip, hostname or both) in the
   Tui ([#124](https://github.com/fujiapple852/trippy/issues/124))
 - Added ability to expand and collapse the number of hosts displays per hop in the
   Tui ([#124](https://github.com/fujiapple852/trippy/issues/124))


### PR DESCRIPTION
Closes #1797.

Running \`typos\` on the repo today reports a large set of false positives that drown out real typos. The one real typo the scan surfaces is \`thr\` in CHANGELOG.md (\"both) in thr Tui\" → \"both) in the Tui\").

This PR:

* Adds a repo-level \`.typos.toml\` that excludes:
  * \`crates/trippy-tui/locales.toml\` — translated UI strings, maintained via the i18n workflow rather than a typo scanner.
  * \`crates/trippy-tui/tests/resources/snapshots/*elvish*.snap\` — generated shell-completion snapshot written verbatim by the test suite.
  * And keeps the following as valid words / identifiers:
    * \`ratatui\` (crate name — not \"ratatouille\")
    * \`ECT\` / \`NotECT\` (RFC 3168 ECN values, used in \`crates/trippy-core/src/types.rs\` and its tests)
    * \`ba\` (hex byte appearing inside \`hex_literal!()\` packet-dump fixtures in \`crates/trippy-core/src/net/ipv6.rs\`)
* Fixes the real typo in \`CHANGELOG.md\`.

## Testing

\`\`\`
$ brew install typos-cli
$ typos .
$ echo $?
0
\`\`\`

The scan now returns zero findings, so a CI wiring step (e.g. a \`typos-cli\` GitHub Action) could be added in a follow-up without immediate red.