### PR TITLE
chore: divest Ubuntu `noble` and `jammy` and add support for `resolute`

### DIFF
--- a/ubuntu-ppa/Dockerfile
+++ b/ubuntu-ppa/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble
+FROM ubuntu:resolute
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/ubuntu-ppa/release.sh
+++ b/ubuntu-ppa/release.sh
@@ -18,7 +18,7 @@ UPSTREAM="0.14.0-dev"
 REVISION=1
 
 # The Ubuntu series to build for
-SERIES=("noble" "jammy")
+SERIES=("resolute")
 
 TARBALL="trippy_${UPSTREAM}.orig.tar.gz"
 PACKAGE="trippy"


### PR DESCRIPTION
Closes #1810