### PR TITLE
fix(tui): centre the frequency% chart on the highest-frequency bucket

### DIFF
--- a/crates/trippy-tui/src/frontend/render/histogram.rs
+++ b/crates/trippy-tui/src/frontend/render/histogram.rs
@@ -49,9 +49,17 @@ pub fn render(f: &mut Frame<'_>, app: &TuiApp, rect: Rect) {
 /// `BarChart` renders bars left-to-right and simply clips whatever doesn't fit, so without this
 /// the highest-frequency bucket can be pushed off-screen if it doesn't happen to be amongst the
 /// first buckets shown.
+///
+/// `width` is the full `rect` width passed to `render`, i.e. before the surrounding
+/// `Borders::ALL` block is applied, so two columns (one per side) are reserved for it here.
+/// The bar count itself mirrors `BarChart`'s own sizing rule (`(space + bar_gap) /
+/// (bar_width + bar_gap)`): the last visible bar doesn't need a trailing gap after it, so a
+/// plain `inner_width / bar_and_gap` would undercount by one bar whenever `inner_width mod
+/// bar_and_gap == bar_width`.
 fn windowed_around_peak(freq_data: &[(String, u64)], width: u16) -> &[(String, u64)] {
     let bar_and_gap = BAR_WIDTH + BAR_GAP;
-    let max_bars = usize::from(width / bar_and_gap).max(1);
+    let inner_width = width.saturating_sub(2);
+    let max_bars = usize::from((inner_width + BAR_GAP) / bar_and_gap).max(1);
     if freq_data.len() <= max_bars {
         return freq_data;
     }
@@ -106,9 +114,9 @@ mod tests {
 
     #[test]
     fn centres_on_the_peak_when_it_does_not_fit() {
-        // width 20 / (bar_width 4 + bar_gap 1) == 4 bars visible.
+        // rect width 22 -> inner width 20 -> (20 + 1) / (4 + 1) == 4 bars visible.
         let freq_data = data(&[1, 1, 1, 1, 1, 9, 1, 1, 1, 1, 1]);
-        let visible = windowed_around_peak(&freq_data, 20);
+        let visible = windowed_around_peak(&freq_data, 22);
         assert_eq!(visible.len(), 4);
         assert!(visible.iter().any(|(_, c)| *c == 9));
     }
@@ -116,7 +124,7 @@ mod tests {
     #[test]
     fn clamps_the_window_to_the_start_of_the_data() {
         let freq_data = data(&[9, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
-        let visible = windowed_around_peak(&freq_data, 20);
+        let visible = windowed_around_peak(&freq_data, 22);
         assert_eq!(visible.len(), 4);
         assert_eq!(visible[0].1, 9);
     }
@@ -124,7 +132,7 @@ mod tests {
     #[test]
     fn clamps_the_window_to_the_end_of_the_data() {
         let freq_data = data(&[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 9]);
-        let visible = windowed_around_peak(&freq_data, 20);
+        let visible = windowed_around_peak(&freq_data, 22);
         assert_eq!(visible.len(), 4);
         assert_eq!(visible.last().unwrap().1, 9);
     }
@@ -134,5 +142,27 @@ mod tests {
         let freq_data = data(&[1, 2, 3]);
         let visible = windowed_around_peak(&freq_data, 1);
         assert_eq!(visible.len(), 1);
+    }
+
+    #[test]
+    fn accounts_for_the_last_bar_not_needing_a_trailing_gap() {
+        // rect width 21 -> inner width 19 -> the widget's own sizing rule
+        // ((space + gap) / (bar_width + gap) == (19 + 1) / 5 == 4) fits one more
+        // bar than a naive `inner_width / (bar_width + gap)` (19 / 5 == 3) would,
+        // because the last visible bar doesn't need a trailing gap after it.
+        let freq_data = data(&[1, 2, 3, 4, 5, 6]);
+        let visible = windowed_around_peak(&freq_data, 21);
+        assert_eq!(visible.len(), 4);
+    }
+
+    #[test]
+    fn accounts_for_the_two_columns_taken_by_the_border() {
+        // A rounded `Borders::ALL` block consumes one column on each side, so the
+        // bar area only has `rect.width - 2` columns to work with, not the full
+        // `rect.width` passed in here. rect width 20 -> inner width 18 -> (18 + 1)
+        // / 5 == 3 bars. Treating the full rect width as usable would give 4.
+        let freq_data = data(&[1, 2, 3, 4, 5, 6]);
+        let visible = windowed_around_peak(&freq_data, 20);
+        assert_eq!(visible.len(), 3);
     }
 }

--- a/crates/trippy-tui/src/frontend/render/histogram.rs
+++ b/crates/trippy-tui/src/frontend/render/histogram.rs
@@ -7,11 +7,16 @@ use ratatui::widgets::{BarChart, Block, BorderType, Borders};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+/// The width, in columns, occupied by a single bar (including its trailing gap).
+const BAR_WIDTH: u16 = 4;
+const BAR_GAP: u16 = 1;
+
 /// Render a histogram of ping frequencies.
 pub fn render(f: &mut Frame<'_>, app: &TuiApp, rect: Rect) {
     let selected_hop = app.selected_hop_or_target();
     let freq_data = sample_frequency(selected_hop.samples());
-    let freq_data_ref: Vec<_> = freq_data.iter().map(|(b, c)| (b.as_str(), *c)).collect();
+    let visible = windowed_around_peak(&freq_data, rect.width);
+    let freq_data_ref: Vec<_> = visible.iter().map(|(b, c)| (b.as_str(), *c)).collect();
     let barchart = BarChart::default()
         .block(
             Block::default()
@@ -26,8 +31,8 @@ pub fn render(f: &mut Frame<'_>, app: &TuiApp, rect: Rect) {
                 .border_style(Style::default().fg(app.tui_config.theme.border)),
         )
         .data(freq_data_ref.as_slice())
-        .bar_width(4)
-        .bar_gap(1)
+        .bar_width(BAR_WIDTH)
+        .bar_gap(BAR_GAP)
         .bar_style(Style::default().fg(app.tui_config.theme.frequency_chart_bar))
         .value_style(
             Style::default()
@@ -36,6 +41,29 @@ pub fn render(f: &mut Frame<'_>, app: &TuiApp, rect: Rect) {
                 .add_modifier(Modifier::BOLD),
         );
     f.render_widget(barchart, rect);
+}
+
+/// Return the slice of `freq_data` that fits within `width` columns, centred on the bucket
+/// with the highest frequency.
+///
+/// `BarChart` renders bars left-to-right and simply clips whatever doesn't fit, so without this
+/// the highest-frequency bucket can be pushed off-screen if it doesn't happen to be amongst the
+/// first buckets shown.
+fn windowed_around_peak(freq_data: &[(String, u64)], width: u16) -> &[(String, u64)] {
+    let bar_and_gap = BAR_WIDTH + BAR_GAP;
+    let max_bars = usize::from(width / bar_and_gap).max(1);
+    if freq_data.len() <= max_bars {
+        return freq_data;
+    }
+    let peak_index = freq_data
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, (_, count))| *count)
+        .map_or(0, |(i, _)| i);
+    let start = peak_index
+        .saturating_sub(max_bars / 2)
+        .min(freq_data.len() - max_bars);
+    &freq_data[start..start + max_bars]
 }
 
 /// Return the frequency % grouped by sample duration.
@@ -55,4 +83,56 @@ fn sample_frequency(samples: &[Duration]) -> Vec<(String, u64)> {
             (ping, freq_pct)
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn data(counts: &[u64]) -> Vec<(String, u64)> {
+        counts
+            .iter()
+            .enumerate()
+            .map(|(i, c)| (i.to_string(), *c))
+            .collect()
+    }
+
+    #[test]
+    fn returns_all_data_when_it_fits() {
+        let freq_data = data(&[1, 2, 3]);
+        let visible = windowed_around_peak(&freq_data, 100);
+        assert_eq!(visible, freq_data.as_slice());
+    }
+
+    #[test]
+    fn centres_on_the_peak_when_it_does_not_fit() {
+        // width 20 / (bar_width 4 + bar_gap 1) == 4 bars visible.
+        let freq_data = data(&[1, 1, 1, 1, 1, 9, 1, 1, 1, 1, 1]);
+        let visible = windowed_around_peak(&freq_data, 20);
+        assert_eq!(visible.len(), 4);
+        assert!(visible.iter().any(|(_, c)| *c == 9));
+    }
+
+    #[test]
+    fn clamps_the_window_to_the_start_of_the_data() {
+        let freq_data = data(&[9, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
+        let visible = windowed_around_peak(&freq_data, 20);
+        assert_eq!(visible.len(), 4);
+        assert_eq!(visible[0].1, 9);
+    }
+
+    #[test]
+    fn clamps_the_window_to_the_end_of_the_data() {
+        let freq_data = data(&[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 9]);
+        let visible = windowed_around_peak(&freq_data, 20);
+        assert_eq!(visible.len(), 4);
+        assert_eq!(visible.last().unwrap().1, 9);
+    }
+
+    #[test]
+    fn handles_a_width_too_small_for_a_single_bar() {
+        let freq_data = data(&[1, 2, 3]);
+        let visible = windowed_around_peak(&freq_data, 1);
+        assert_eq!(visible.len(), 1);
+    }
 }

--- a/crates/trippy-tui/src/frontend/render/histogram.rs
+++ b/crates/trippy-tui/src/frontend/render/histogram.rs
@@ -16,7 +16,10 @@ pub fn render(f: &mut Frame<'_>, app: &TuiApp, rect: Rect) {
     let selected_hop = app.selected_hop_or_target();
     let freq_data = sample_frequency(selected_hop.samples());
     let visible = windowed_around_peak(&freq_data, rect.width);
-    let freq_data_ref: Vec<_> = visible.iter().map(|(b, c)| (b.as_str(), *c)).collect();
+    let freq_data_ref: Vec<_> = visible
+        .iter()
+        .map(|bucket| (bucket.label.as_str(), bucket.freq_pct))
+        .collect();
     let barchart = BarChart::default()
         .block(
             Block::default()
@@ -43,6 +46,21 @@ pub fn render(f: &mut Frame<'_>, app: &TuiApp, rect: Rect) {
     f.render_widget(barchart, rect);
 }
 
+/// A single bucket of the frequency histogram.
+#[derive(Debug, PartialEq, Eq)]
+struct Bucket {
+    /// The bucket's label (the round-trip time, in ms, as a string).
+    label: String,
+    /// The number of samples that fell into this bucket.
+    ///
+    /// This is the raw sample count, not `freq_pct` -- it must be used (rather than the
+    /// truncated integer percentage) to find the bucket with the highest frequency, as two
+    /// buckets with different counts can round down to the same displayed percentage.
+    count: u64,
+    /// The displayed frequency, as a percentage of all samples, truncated to an integer.
+    freq_pct: u64,
+}
+
 /// Return the slice of `freq_data` that fits within `width` columns, centred on the bucket
 /// with the highest frequency.
 ///
@@ -56,7 +74,7 @@ pub fn render(f: &mut Frame<'_>, app: &TuiApp, rect: Rect) {
 /// (bar_width + bar_gap)`): the last visible bar doesn't need a trailing gap after it, so a
 /// plain `inner_width / bar_and_gap` would undercount by one bar whenever `inner_width mod
 /// bar_and_gap == bar_width`.
-fn windowed_around_peak(freq_data: &[(String, u64)], width: u16) -> &[(String, u64)] {
+fn windowed_around_peak(freq_data: &[Bucket], width: u16) -> &[Bucket] {
     let bar_and_gap = BAR_WIDTH + BAR_GAP;
     let inner_width = width.saturating_sub(2);
     let max_bars = usize::from((inner_width + BAR_GAP) / bar_and_gap).max(1);
@@ -66,7 +84,7 @@ fn windowed_around_peak(freq_data: &[(String, u64)], width: u16) -> &[(String, u
     let peak_index = freq_data
         .iter()
         .enumerate()
-        .max_by_key(|(_, (_, count))| *count)
+        .max_by_key(|(_, bucket)| bucket.count)
         .map_or(0, |(i, _)| i);
     let start = peak_index
         .saturating_sub(max_bars / 2)
@@ -75,7 +93,7 @@ fn windowed_around_peak(freq_data: &[(String, u64)], width: u16) -> &[(String, u
 }
 
 /// Return the frequency % grouped by sample duration.
-fn sample_frequency(samples: &[Duration]) -> Vec<(String, u64)> {
+fn sample_frequency(samples: &[Duration]) -> Vec<Bucket> {
     let sample_count = samples.len();
     let mut count_by_duration: BTreeMap<u128, u64> = BTreeMap::new();
     for sample in samples {
@@ -86,9 +104,12 @@ fn sample_frequency(samples: &[Duration]) -> Vec<(String, u64)> {
     count_by_duration
         .iter()
         .map(|(ping, count)| {
-            let ping = format!("{ping}");
             let freq_pct = ((*count as f64 / sample_count as f64) * 100_f64) as u64;
-            (ping, freq_pct)
+            Bucket {
+                label: format!("{ping}"),
+                count: *count,
+                freq_pct,
+            }
         })
         .collect()
 }
@@ -97,11 +118,15 @@ fn sample_frequency(samples: &[Duration]) -> Vec<(String, u64)> {
 mod tests {
     use super::*;
 
-    fn data(counts: &[u64]) -> Vec<(String, u64)> {
+    fn data(counts: &[u64]) -> Vec<Bucket> {
         counts
             .iter()
             .enumerate()
-            .map(|(i, c)| (i.to_string(), *c))
+            .map(|(i, c)| Bucket {
+                label: i.to_string(),
+                count: *c,
+                freq_pct: *c,
+            })
             .collect()
     }
 
@@ -118,7 +143,7 @@ mod tests {
         let freq_data = data(&[1, 1, 1, 1, 1, 9, 1, 1, 1, 1, 1]);
         let visible = windowed_around_peak(&freq_data, 22);
         assert_eq!(visible.len(), 4);
-        assert!(visible.iter().any(|(_, c)| *c == 9));
+        assert!(visible.iter().any(|bucket| bucket.count == 9));
     }
 
     #[test]
@@ -126,7 +151,7 @@ mod tests {
         let freq_data = data(&[9, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
         let visible = windowed_around_peak(&freq_data, 22);
         assert_eq!(visible.len(), 4);
-        assert_eq!(visible[0].1, 9);
+        assert_eq!(visible[0].count, 9);
     }
 
     #[test]
@@ -134,7 +159,7 @@ mod tests {
         let freq_data = data(&[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 9]);
         let visible = windowed_around_peak(&freq_data, 22);
         assert_eq!(visible.len(), 4);
-        assert_eq!(visible.last().unwrap().1, 9);
+        assert_eq!(visible.last().unwrap().count, 9);
     }
 
     #[test]
@@ -164,5 +189,56 @@ mod tests {
         let freq_data = data(&[1, 2, 3, 4, 5, 6]);
         let visible = windowed_around_peak(&freq_data, 20);
         assert_eq!(visible.len(), 3);
+    }
+
+    #[test]
+    fn picks_the_peak_by_raw_count_not_truncated_percentage() {
+        // Two buckets whose *truncated* percentages tie at 33%, but whose raw counts
+        // differ: 100 samples in bucket 0 (33.0%) and 133 samples in bucket 5 (33.25%
+        // of 400, i.e. it is the true peak). Selecting on `freq_pct` alone would pick
+        // whichever tied bucket comes first (index 0); selecting on `count` must pick
+        // index 5.
+        let freq_data: Vec<Bucket> = [
+            (0, 100_u64),
+            (1, 1),
+            (2, 1),
+            (3, 1),
+            (4, 1),
+            (5, 133),
+            (6, 1),
+            (7, 1),
+            (8, 1),
+            (9, 1),
+            (10, 1),
+        ]
+        .into_iter()
+        .map(|(i, count)| Bucket {
+            label: i.to_string(),
+            count,
+            freq_pct: 33, // both tie once truncated to an integer percentage
+        })
+        .collect();
+        let visible = windowed_around_peak(&freq_data, 22);
+        assert_eq!(visible.len(), 4);
+        assert!(visible.iter().any(|bucket| bucket.count == 133));
+    }
+
+    #[test]
+    fn sample_frequency_reports_raw_counts_alongside_truncated_percentages() {
+        // 3 samples: durations 1ms, 1ms, 2ms -> bucket "1" has count 2 (66%),
+        // bucket "2" has count 1 (33%). The raw counts must reflect the actual
+        // sample distribution, not just the truncated percentages.
+        let samples = [
+            Duration::from_millis(1),
+            Duration::from_millis(1),
+            Duration::from_millis(2),
+        ];
+        let buckets = sample_frequency(&samples);
+        let bucket_1 = buckets.iter().find(|b| b.label == "1").unwrap();
+        let bucket_2 = buckets.iter().find(|b| b.label == "2").unwrap();
+        assert_eq!(bucket_1.count, 2);
+        assert_eq!(bucket_1.freq_pct, 66);
+        assert_eq!(bucket_2.count, 1);
+        assert_eq!(bucket_2.freq_pct, 33);
     }
 }


### PR DESCRIPTION
## Summary
Fixes #90.

The frequency% barchart shows the first N round-trip-time buckets (however many fit the terminal width), sorted ascending by duration. `ratatui::widgets::BarChart` renders left-to-right and just clips whatever doesn't fit — it has no auto-centring — so if the bucket with the highest frequency happened to have a longer RTT than what fits on screen, it was pushed off-screen and never shown.

- Added `windowed_around_peak`, which slices the (already-sorted) bucket list down to however many bars fit in `rect.width` given the chart's `bar_width`/`bar_gap`, centred on the index of the highest-frequency bucket (clamped to the start/end of the data when the peak is near an edge).
- `render` now passes the windowed slice to `BarChart` instead of the full bucket list.
- `bar_width`/`bar_gap` were pulled into named constants so the windowing math and the chart itself can't drift out of sync.

## Test plan
- [x] Added 5 unit tests for `windowed_around_peak`: fits-without-windowing, peak-in-the-middle, peak-clamped-to-start, peak-clamped-to-end, width-too-small-for-one-bar.
- [x] `cargo test --package trippy-tui histogram` — 5/5 pass.
- [x] `cargo check --workspace --all-features --tests` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-features --tests -- -Dwarnings` — clean.

Note: this PR was prepared with the assistance of Claude Code, per the guidance in this repo's `AGENTS.md`. The change was validated with an actual local build/test/clippy/fmt run (via a `rust:latest` container) before submission, not just written and shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)