### PR TITLE
ci: split cross caches by target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
       - name: Use Cross
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- add the cross-compilation target to the `Swatinem/rust-cache` key
- keep NetBSD and FreeBSD host build artifacts in separate caches

## Root cause

The NetBSD and FreeBSD matrix jobs used the same automatic `build-cross` cache key. The FreeBSD job restored a host-side Cargo build script from that shared cache which required newer glibc symbols than the FreeBSD Cross container provides, causing the [FreeBSD build failure](https://github.com/fujiapple852/trippy/actions/runs/29203530773/job/86678824239).

Adding `matrix.target` to the key prevents artifacts built in one Cross container from being reused in the other.

## Validation

- confirmed the branch is one commit ahead of `master`
- confirmed only `.github/workflows/ci.yml` changed
- inspected the rendered workflow block and verified both matrix targets resolve to distinct cache keys

The GitHub Actions run will provide the end-to-end validation.