### PR TITLE
fix: remove redundant hostname borrow

### DIFF
--- a/examples/toy-traceroute/src/main.rs
+++ b/examples/toy-traceroute/src/main.rs
@@ -84,7 +84,7 @@ fn main() -> anyhow::Result<()> {
         .build()?;
     println!(
         "traceroute to {} ({}), {} hops max, {} byte packets",
-        &hostname,
+        hostname,
         tracer.target_addr(),
         tracer.max_ttl().0,
         tracer.packet_size().0


### PR DESCRIPTION
## Summary

Remove a redundant borrow from the toy traceroute example's `println!` arguments.

## Root cause

Rust 1.97 introduced/enabled the `clippy::useless_borrows_in_formatting` diagnostic exercised by the repository's `-Dwarnings` configuration. The [Linux Clippy job](https://github.com/fujiapple852/trippy/actions/runs/29203530773/job/86835436701) therefore rejects `&hostname`; formatting accepts `hostname` directly without taking ownership.

## Validation

- applied Clippy's suggested replacement
- confirmed the branch is one commit ahead of `master`
- confirmed only `examples/toy-traceroute/src/main.rs` changed, with one line replaced

The pull request's CI run will execute the complete workspace Clippy check.