### PR TITLE
fix: guard packet payload slicing against malformed lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Guard packet payload slicing against malformed lengths to prevent a panic on
+  crafted ICMP extension objects and nested IPv4
+  headers ([#1855](https://github.com/fujiapple852/trippy/pull/1855))
 - Default the `system` `address-family` to `ipv4-then-ipv6` for non-`system`
   resolvers ([#1635](https://github.com/fujiapple852/trippy/issues/1635))
 - Locale parsing fails for valid BCP 47 language tags ([#1631](https://github.com/fujiapple852/trippy/pull/1631))

--- a/crates/trippy-packet/src/icmp_extension.rs
+++ b/crates/trippy-packet/src/icmp_extension.rs
@@ -460,7 +460,13 @@ pub mod extension_object {
 
         #[must_use]
         pub fn payload(&self) -> &[u8] {
-            &self.buf.as_slice()[Self::minimum_packet_size()..usize::from(self.get_length())]
+            // `get_length()` is read straight from the packet, so a malformed
+            // object can make it smaller than the header or larger than the
+            // buffer. Clamp both ends so slicing cannot panic.
+            let bytes = self.buf.as_slice();
+            let start = Self::minimum_packet_size();
+            let end = usize::from(self.get_length()).clamp(start, bytes.len());
+            &bytes[start..end]
         }
     }
 
@@ -550,6 +556,37 @@ pub mod extension_object {
             );
             assert_eq!(ClassSubType(1), object.get_class_subtype());
             assert_eq!([0x04, 0xbb, 0x41, 0x01], object.payload());
+        }
+
+        #[test]
+        fn test_payload_length_below_minimum() {
+            // A length field smaller than the header would slice [4..0]. The
+            // payload must be empty rather than panic.
+            let buf = [0x00, 0x00, 0x01, 0x01];
+            let object = ExtensionObjectPacket::new_view(&buf).unwrap();
+            assert_eq!(0, object.get_length());
+            assert!(object.payload().is_empty());
+        }
+
+        #[test]
+        fn test_payload_length_beyond_buffer() {
+            // A length field larger than the buffer would slice past the end.
+            // The payload must stop at the buffer, not panic.
+            let buf = [0xff, 0xff, 0x01, 0x01];
+            let object = ExtensionObjectPacket::new_view(&buf).unwrap();
+            assert_eq!(0xffff, object.get_length());
+            assert_eq!(
+                &buf[ExtensionObjectPacket::minimum_packet_size()..],
+                object.payload()
+            );
+        }
+
+        #[test]
+        fn test_debug_does_not_panic_on_malformed_length() {
+            // Debug prints the payload, so it must survive a bad length too.
+            let buf = [0xff, 0xff, 0x01, 0x01];
+            let object = ExtensionObjectPacket::new_view(&buf).unwrap();
+            let _ = format!("{object:?}");
         }
     }
 }

--- a/crates/trippy-packet/src/ipv4.rs
+++ b/crates/trippy-packet/src/ipv4.rs
@@ -211,7 +211,13 @@ impl<'a> Ipv4Packet<'a> {
 
     #[must_use]
     pub fn payload(&self) -> &[u8] {
-        let start = Ipv4Packet::minimum_packet_size() + ipv4_options_length(self);
+        // The header length nibble is attacker-controlled (e.g. a nested IPv4
+        // header quoted inside an ICMP error), so `start` can exceed the buffer.
+        // Clamp it, mirroring `get_options_raw` above.
+        let start = std::cmp::min(
+            Ipv4Packet::minimum_packet_size() + ipv4_options_length(self),
+            self.buf.as_slice().len(),
+        );
         &self.buf.as_slice()[start..]
     }
 }
@@ -505,5 +511,16 @@ mod tests {
             Error::InsufficientPacketBuffer(String::from("Ipv4Packet"), SIZE, SIZE - 1),
             err
         );
+    }
+
+    #[test]
+    fn test_payload_header_length_beyond_buffer() {
+        // A minimum sized (20 byte) packet whose IHL nibble claims 15 (60 bytes
+        // of header). ipv4_options_length() then reports 40, so the payload
+        // would start at offset 60. It must clamp to an empty payload, not panic.
+        let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
+        buf[0] = 0x4f; // version 4, IHL 15
+        let packet = Ipv4Packet::new_view(&buf).unwrap();
+        assert!(packet.payload().is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Two payload accessors in `trippy-packet` slice using a length taken straight from the packet, without clamping it against the actual buffer, so a malformed packet can panic the parser.

## Root cause

**`ExtensionObjectPacket::payload`** (`icmp_extension.rs`) sliced `[minimum_packet_size()..get_length()]`. `get_length()` is a `u16` read from the object, so:

- a length below the 4 byte minimum slices `[4..n]` with `n < 4` -> `slice index starts at 4 but ends at n`
- a length beyond the buffer slices past the end -> `range end index N out of range`

`Debug` for `ExtensionObjectPacket` prints `payload()`, so even logging a malformed object hits this.

**`Ipv4Packet::payload`** (`ipv4.rs`) started at `minimum_packet_size() + ipv4_options_length(self)`, where `ipv4_options_length` is driven by the IHL nibble (`(IHL * 4).saturating_sub(20)`, up to 40). On a short packet, `start` runs past the buffer and the `[start..]` slice panics. This one is reachable from the network: the nested IPv4 header quoted inside an ICMP `TimeExceeded` / `DestinationUnreachable` error is only bounded by the outer packet, and `extract_probe_proto_resp` calls `.payload()` on it (`trippy-core/src/net/ipv4.rs`, via `extract_echo_request` / `extract_udp_packet`).

The impact is a panic (crash of the trippy process), not memory unsafety; the crate is `#![forbid(unsafe_code)]`. The same clamping is already done in `Ipv6Packet::payload`, `TcpPacket::payload` and the `*_options_raw` accessors, so these two spots look like the ones that were missed rather than a deliberate difference.

## Fix

Clamp both, matching the existing style:

```rust
// ExtensionObjectPacket::payload
let end = usize::from(self.get_length()).clamp(start, bytes.len());

// Ipv4Packet::payload
let start = std::cmp::min(minimum + ipv4_options_length(self), buf.len());
```

Output for valid packets is byte-for-byte identical; only out-of-range inputs change, from a panic to a truncated/empty slice.

## Validation

- Added four tests: extension length below minimum, extension length beyond buffer, `Debug` on a malformed extension object, and an IPv4 header claiming IHL 15 on a 20 byte packet.
- Confirmed they fail (panic) on `master` and pass with the fix.
- `cargo test -p trippy-packet` green (181 passed), `cargo clippy -p trippy-packet --all-features --tests -- -Dwarnings` clean, `cargo fmt --check` clean.
- Only `trippy-packet` touched, no behaviour change for well-formed packets.

I could only build and test the `trippy-packet` crate in my environment (`trippy-core` pulls `windows-sys`, whose `dlltool` is broken under my GNU toolchain), so the network-path reachability above is from reading `trippy-core`, not a run. CI will exercise the full workspace.
