### PR TITLE
fix(packet): clamp Ipv4Packet::payload() to avoid panic on truncated header

### DIFF
--- a/crates/trippy-packet/src/ipv4.rs
+++ b/crates/trippy-packet/src/ipv4.rs
@@ -211,7 +211,10 @@ impl<'a> Ipv4Packet<'a> {
 
     #[must_use]
     pub fn payload(&self) -> &[u8] {
-        let start = Ipv4Packet::minimum_packet_size() + ipv4_options_length(self);
+        let start = std::cmp::min(
+            Ipv4Packet::minimum_packet_size() + ipv4_options_length(self),
+            self.buf.as_slice().len(),
+        );
         &self.buf.as_slice()[start..]
     }
 }
@@ -505,5 +508,20 @@ mod tests {
             Error::InsufficientPacketBuffer(String::from("Ipv4Packet"), SIZE, SIZE - 1),
             err
         );
+    }
+
+    // A view buffer whose IHL field claims a header longer than the buffer itself
+    // (e.g. an attacker-controlled nested "original datagram" inside an ICMP error
+    // response) must not panic when `payload()` is called. `new_view` only checks
+    // the 20-byte minimum, so IHL=15 claims a 60-byte header on a 20-byte buffer;
+    // without clamping, `payload()` would slice `buf[60..]` and panic. Mirrors the
+    // clamping already present in `get_options_raw()` and `Ipv6Packet::payload()`.
+    #[test]
+    fn test_payload_header_length_exceeds_buffer() {
+        let mut buf = [0_u8; Ipv4Packet::minimum_packet_size()];
+        buf[0] = 0x4f; // version=4, IHL=15 (header claims 60 bytes)
+        let packet = Ipv4Packet::new_view(&buf).unwrap();
+        assert_eq!(15, packet.get_header_length());
+        assert!(packet.payload().is_empty());
     }
 }


### PR DESCRIPTION
_Disclosure: prepared with AI assistance (Claude Opus 5). I traced the receive path and reproduced the panic with a failing test against the real `payload()` before opening this._

### Problem

`Ipv4Packet::payload()` (`crates/trippy-packet/src/ipv4.rs`) computes `start = minimum_packet_size() + ipv4_options_length(self)` and slices `&self.buf.as_slice()[start..]` **without clamping** to the buffer length. `new_view()` only checks the 20-byte minimum, and the IHL field (4 bits, 0–15) is not tied to the actual buffer length. A view over a 20-byte buffer with IHL=15 makes `start = 60`, so `buf[60..]` panics:

```
range start index 60 out of range for slice of length 20
```

This is reachable from the network. When parsing an ICMP `TimeExceeded` / `DestinationUnreachable` response, `net/ipv4.rs` builds an `Ipv4Packet::new_view()` over the **nested "original datagram"** carried in the ICMP body (`extract_probe_resp` → `Ipv4Packet::new_view(packet.payload_raw())` → `extract_probe_proto_resp` → `extract_echo_request` / `extract_udp_packet` / `extract_tcp_packet`, each of which calls `ipv4.payload()`). Those nested bytes are attacker-controlled and are not validated by the kernel the way the outer packet is. The parse — and the panic — happen before any correlation with sent probes, so a single crafted ICMP error delivered to the host while a trace is running aborts it. Sibling accessors `get_options_raw()` and `Ipv6Packet::payload()` already clamp; `payload()` was the one that didn't.

### Fix

Clamp `start` to the buffer length, mirroring `get_options_raw()`:

```rust
let start = std::cmp::min(
    Ipv4Packet::minimum_packet_size() + ipv4_options_length(self),
    self.buf.as_slice().len(),
);
```

### Verification

- Added `test_payload_header_length_exceeds_buffer`: a 20-byte view with IHL=15 must return an empty payload instead of panicking. It panics against the old code and passes with the fix.
- Full `trippy-packet` suite green (178 + 2 passing).

### Note (separate, minor)

`extract_udp_packet` computes `nested.get_length() - UdpPacket::minimum_packet_size()` on an attacker-supplied UDP length; values `< 8` underflow (panic in a debug build, wrap in release). Happy to fold a bounds check into this PR or file it separately — whichever you prefer.